### PR TITLE
[Issue #59] Add active filter chips above table

### DIFF
--- a/frontend/src/pages/BooksPage.jsx
+++ b/frontend/src/pages/BooksPage.jsx
@@ -20,6 +20,8 @@ import {
   FormControl,
   InputLabel,
   Skeleton,
+  Chip,
+  Button,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import ClearIcon from '@mui/icons-material/Clear';
@@ -216,6 +218,53 @@ function BooksPage() {
         <Typography variant="body2" color="text.secondary">
           Showing {filteredBooks.length} of {books.length} books
         </Typography>
+        {(debouncedSearchTerm || availabilityFilter !== AVAILABILITY_FILTERS.ALL) && (
+          <Box
+            sx={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: 1,
+              mt: 2,
+              alignItems: 'center',
+            }}
+          >
+            {debouncedSearchTerm && (
+              <Chip
+                label={`Search: "${debouncedSearchTerm}"`}
+                onDelete={() => {
+                  setSearchTerm('');
+                  setDebouncedSearchTerm('');
+                }}
+                size="small"
+                variant="outlined"
+                aria-label={`Remove search filter: ${debouncedSearchTerm}`}
+              />
+            )}
+            {availabilityFilter !== AVAILABILITY_FILTERS.ALL && (
+              <Chip
+                label={`Availability: ${AVAILABILITY_FILTER_LABELS[availabilityFilter]}`}
+                onDelete={() => setAvailabilityFilter(AVAILABILITY_FILTERS.ALL)}
+                size="small"
+                variant="outlined"
+                aria-label={`Remove availability filter: ${AVAILABILITY_FILTER_LABELS[availabilityFilter]}`}
+              />
+            )}
+            {debouncedSearchTerm && availabilityFilter !== AVAILABILITY_FILTERS.ALL && (
+              <Button
+                size="small"
+                onClick={() => {
+                  setSearchTerm('');
+                  setDebouncedSearchTerm('');
+                  setAvailabilityFilter(AVAILABILITY_FILTERS.ALL);
+                }}
+                sx={{ ml: 0.5 }}
+                aria-label="Clear all filters"
+              >
+                Clear all filters
+              </Button>
+            )}
+          </Box>
+        )}
       </Paper>
       {filteredBooks.length === 0 &&
         (() => {


### PR DESCRIPTION
## Summary
Closes #59

Implemented active filter chips on BooksPage that display which filters are currently applied (search term and availability filter). Users can see at a glance what filters are active and easily remove them by clicking the X icon on each chip, or use the "Clear all filters" button to remove all filters at once.

## Changes
**Frontend:**
- Added Chip and Button imports to Material UI components in BooksPage.jsx
- Implemented filter chips display section below result count (inside Paper container)
- Search chip displays when debounced search term is active with format: `Search: "[term]"`
- Availability chip displays when availability filter is not "All Books" with format: `Availability: [filter]`
- "Clear all filters" button appears when both search and availability filters are active
- Each chip has an onDelete handler that clears its specific filter
- Added ARIA labels for accessibility (e.g., "Remove search filter: [term]")
- Responsive flex layout with gap spacing and wrapping for mobile devices

**Testing:**
- Added 8 comprehensive tests in BooksPage.test.jsx for chip functionality
- Tests cover: chip rendering based on filter state, delete interactions, "clear all" button, accessibility
- All 32 tests passing (including existing tests to ensure no regressions)
- Used container.querySelector to access MUI Chip delete icons in tests

## Testing Completed by Claude
- ✅ All automated tests pass (32/32 tests, 0 failures)
- ✅ ESLint passes with no warnings or errors
- ✅ Prettier formatting applied successfully
- ✅ Frontend builds successfully (production build verified)
- ✅ No console.log statements in code
- ✅ Standards compliance verified (MUI patterns, accessibility, responsive design)

See verification document at `.claude/temp/VERIFICATION-59-REMOVE.md` for detailed test results.

## Additional Testing Needed
- [ ] Manual browser testing - verify chips appear and disappear correctly
- [ ] Click chip delete icons to verify filters clear as expected
- [ ] Apply both filters and test "Clear all filters" button
- [ ] Test responsive design on mobile viewport (chips should wrap)
- [ ] Test keyboard navigation through chips (Tab key, Enter/Space to delete)
- [ ] Test with screen reader to verify ARIA labels are announced correctly

## Verification Document
Detailed test results and manual testing instructions available at: `.claude/temp/VERIFICATION-59-REMOVE.md`

## Screenshots
Please test in browser and observe:
- Chips appear with outlined variant and small size
- Delete icons (X) are clearly visible
- "Clear all filters" button appears between chips when both filters active
- Responsive wrapping on narrow screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)