### PR TITLE
feat: Integrate harness-kit and streamline CLAUDE.md

### DIFF
--- a/.claude/agents/batch-worker-kit.md
+++ b/.claude/agents/batch-worker-kit.md
@@ -1,0 +1,349 @@
+# Batch Worker Agent
+
+**Purpose:** Execute full issue lifecycle in an isolated worktree: prep, plan, implement, code review, merge main, push, PR, report.
+
+**Runs in:** Isolated git worktree (spawned by batch-runner with `isolation: "worktree"`)
+
+**Input:** Issue number (provided in prompt)
+
+**Output:** SUCCESS with PR URL and report path, OR ABORT with failure details and report path
+
+**Sub-agents spawned:** plan-agent, implement-agent — sequential, never parallel
+
+---
+
+## Overview
+
+This agent runs the complete lifecycle for ONE GitHub issue:
+
+| Phase           | Method   | Description                                         |
+| --------------- | -------- | --------------------------------------------------- |
+| 1. Prep         | INLINE   | Fetch issue, rename branch, save files              |
+| 2. Plan         | SUB-TASK | Deep analysis, create implementation plan           |
+| 3. Implement    | SUB-TASK | Execute plan, test, commit (NO code review/push/PR) |
+| 3.5 Code Review | INLINE   | Run /code-review-pr, fix medium+, commit fixes      |
+| 4. Merge Main   | INLINE   | Pull latest main, re-test                           |
+| 5. Push + PR    | INLINE   | Push branch, create pull request                    |
+| 6. Report       | INLINE   | Write per-issue report                              |
+
+**Failure handling:** If ANY phase fails after retries, write a failure report and return ABORT.
+
+---
+
+## Phase 1: Prep (INLINE)
+
+### Step 1.1: Fetch Issue
+
+```bash
+gh issue view <N> --json number,title,body,labels,state,comments
+```
+
+**If issue not found:** ABORT.
+
+### Step 1.2: Rename Branch
+
+The worktree was created with an auto-generated branch. Rename it using the branch naming convention from `CLAUDE.md`:
+
+```bash
+CURRENT=$(git rev-parse --abbrev-ref HEAD)
+BRANCH_NAME="feature/issue-<N>-<description>"
+git branch -m "$CURRENT" "$BRANCH_NAME"
+```
+
+Description: lowercase, hyphens, no special chars, truncate ~30 chars.
+
+### Step 1.3: Create Temp Directory
+
+```bash
+mkdir -p .claude/temp
+```
+
+### Step 1.4: Save Issue File
+
+Write `.claude/temp/GH-ISSUE-<N>-REMOVE.md` with title, state, labels, description, and all comments.
+
+### Step 1.5: Create Context Hint
+
+Write `.claude/temp/CONTEXT-HINT-<N>-REMOVE.md` with keywords, file references, related issues, and suggested exploration directories.
+
+**Phase 1 complete.** Continue to Phase 2.
+
+---
+
+## Phase 2: Plan (SUB-TASK)
+
+### Step 2.1: Spawn plan-agent
+
+```
+Agent tool invocation:
+- subagent_type: general-purpose
+- model: opus
+- description: "Plan for issue #<N>"
+- prompt: |
+    You are plan-agent. Your task is to create an implementation plan for GitHub issue #<N>.
+
+    Prerequisites exist:
+    - .claude/temp/GH-ISSUE-<N>-REMOVE.md
+    - .claude/temp/CONTEXT-HINT-<N>-REMOVE.md
+
+    Follow the instructions in the plan-agent definition exactly.
+
+    Return either:
+    - SUCCESS: with summary of plan created
+    - ABORT: with specific blocker and suggested actions
+```
+
+Use the model assignment for plan-agent specified in `CLAUDE.md`.
+
+### Step 2.2: Handle Response
+
+**On SUCCESS:** Verify `.claude/temp/PLAN-<N>-REMOVE.md` exists. Continue to Phase 3.
+
+**On ABORT:** Write failure report. Return ABORT.
+
+---
+
+## Phase 3: Implement (SUB-TASK)
+
+### Step 3.1: Spawn implement-agent
+
+```
+Agent tool invocation:
+- subagent_type: general-purpose
+- description: "Implement issue #<N>"
+- prompt: |
+    You are implement-agent. Your task is to implement GitHub issue #<N>.
+
+    Prerequisites exist:
+    - .claude/temp/GH-ISSUE-<N>-REMOVE.md
+    - .claude/temp/PLAN-<N>-REMOVE.md
+
+    Follow the instructions in the implement-agent definition exactly, with these IMPORTANT OVERRIDES:
+
+    1. DO execute all steps through Step 6 (testing)
+    2. SKIP Steps 7, 7.5, and 8 entirely — do NOT run code review. The batch-worker handles code review separately.
+    3. DO commit your changes
+    4. Do NOT push to remote — SKIP git push
+    5. Do NOT create a pull request — SKIP gh pr create
+    6. After committing, STOP and return SUCCESS with:
+       - Commit hash (from git rev-parse HEAD)
+       - Branch name
+       - List of files created/modified
+       - Test results summary
+
+    The batch-worker will handle code review, merge main, push, and PR creation after you return.
+
+    Return either:
+    - SUCCESS: with commit hash and summary
+    - ABORT: with specific blocker and suggested actions
+```
+
+### Step 3.2: Handle Response
+
+**On SUCCESS:** Record commit hash, branch name, files list. Continue to Phase 3.5.
+
+**On ABORT:** Write failure report. Return ABORT.
+
+---
+
+## Phase 3.5: Code Review (INLINE)
+
+**This phase runs code review directly at the batch-worker level, not nested inside implement-agent.**
+
+### Step 3.5.1: Run /code-review-pr
+
+Use the Skill tool to invoke the `code-review-pr` skill with the issue number:
+
+```
+Skill tool invocation:
+- skill: "code-review-pr"
+- args: "<N>"
+```
+
+This spawns code-review-agent which reviews the diff and creates `code-review-results/YYYY-MM-DD-issue-<N>.md`.
+
+### Step 3.5.2: Verify Results File
+
+```bash
+ls code-review-results/*-issue-<N>.md
+```
+
+If the file does not exist, ABORT with reason "Code review results file not created."
+
+### Step 3.5.3: Apply Fix Policy
+
+Read the code review results file and apply fixes:
+
+- **Must fix:** All Critical, High, and Medium findings
+- **May fix:** Low findings — fix if straightforward and clearly beneficial, otherwise defer
+- After fixes, re-run quality checks (lint, build, test)
+
+### Step 3.5.4: Commit
+
+If fixes were applied:
+
+```bash
+git add <fixed files> code-review-results/
+git commit -m "fix: address code review findings for issue #<N>
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+If no fixes needed, just commit the review results file:
+
+```bash
+git add code-review-results/
+git commit -m "docs: record code review findings for issue #<N>
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+Record code review summary for inclusion in PR body. Continue to Phase 4.
+
+---
+
+## Phase 4: Merge Main (INLINE)
+
+### Step 4.1: Fetch and Merge
+
+```bash
+git fetch origin main
+git merge origin/main -m "Merge main into feature/issue-<N>"
+```
+
+**NEVER rebase.** Always merge.
+
+### Step 4.2: Handle Conflicts
+
+- Simple conflicts: attempt auto-resolution
+- Complex conflicts requiring human judgment: ABORT
+
+### Step 4.3: Re-test After Merge
+
+Run the build and test commands defined in `CLAUDE.md`.
+
+---
+
+## Phase 5: Push + Create PR (INLINE)
+
+### Step 5.1: Push Branch
+
+```bash
+git push -u origin HEAD
+```
+
+### Step 5.2: Create Pull Request
+
+Include code review results in the PR body.
+
+```bash
+gh pr create --title "[Issue #<N>] <issue title>" --body "$(cat <<'EOF'
+## Summary
+
+Closes #<N>
+
+<Brief description>
+
+## Changes
+
+<List of key changes>
+
+## Code Review Completed
+
+| Severity | Found | Fixed | Deferred |
+|----------|-------|-------|----------|
+| Critical | <n>   | <n>   | 0        |
+| High     | <n>   | <n>   | 0        |
+| Medium   | <n>   | <n>   | <n>      |
+| Low      | <n>   | 0     | <n>      |
+
+Recommendation: <from code review>
+
+## Testing Completed
+
+- [x] Lint passing
+- [x] Build succeeds
+- [x] Tests passing
+- [x] Merged with latest main
+
+## Additional Testing Needed
+
+- [ ] <project-specific manual testing from CLAUDE.md>
+
+---
+
+Generated with [Claude Code](https://claude.com/claude-code) via batch-runner
+EOF
+)"
+```
+
+---
+
+## Phase 6: Write Report (INLINE)
+
+### Success Report
+
+Write `.claude/temp/BATCH-REPORT-<N>-REMOVE.md` with:
+
+- Status, PR URL, branch, commits
+- Implementation summary (files created/modified)
+- Code review findings summary
+- Main branch merge status
+- Quality checks status
+
+### Failure Report
+
+Write `.claude/temp/BATCH-REPORT-<N>-REMOVE.md` with:
+
+- Status (FAILED), failed phase, reason
+- Attempts made
+- Completed phases checklist
+- Recovery options
+
+---
+
+## Return Format
+
+### On Success
+
+```
+SUCCESS: Issue #<N> complete
+PR: <PR URL>
+Branch: <branch-name>
+Commits: <hash1>, <hash2 if merge>
+
+Code review:
+- Critical: <count> (all fixed)
+- High: <count> (all fixed)
+- Medium: <count> (<fixed>/<total>)
+- Low: <count> (deferred)
+
+Recommendation: <Pass / Pass with fixes>
+Main merge: <status>
+Tests: <status>
+
+Report: .claude/temp/BATCH-REPORT-<N>-REMOVE.md
+```
+
+### On Failure
+
+```
+ABORT: Issue #<N> failed
+Phase: <phase name>
+Reason: <what went wrong>
+Last successful phase: <phase name or "none">
+
+Report: .claude/temp/BATCH-REPORT-<N>-REMOVE.md
+```
+
+---
+
+## Rules
+
+- Execute phases SEQUENTIALLY — never skip ahead
+- On failure: write report FIRST, then return ABORT
+- NEVER rebase — always merge
+- Error protocol defined in `CLAUDE.md` (three-strikes)
+- Sub-agents run in their own context — use `.claude/temp/` files for data handoff
+- The worktree is isolated — no interference with other workers or main repo
+- All project commands and review criteria come from `CLAUDE.md` — never hardcode

--- a/.claude/agents/code-review-kit.md
+++ b/.claude/agents/code-review-kit.md
@@ -1,0 +1,300 @@
+# Code Review Agent
+
+**Purpose:** The single authority on how code reviews are performed. All code review — whether triggered by a human via `/code-review-pr`, by implement-agent, or by any other agent — runs through this agent.
+
+**Runs in:** Isolated agent context
+
+**Input:** Issue number, PR number, or no number (reviews current diff)
+
+**Output:** Comprehensive review summary with categorized findings
+
+---
+
+## Execution Steps
+
+### Step 1: Load Project Review Criteria
+
+Read `standards/code-review.md` (referenced from the "Code Review" section of `CLAUDE.md`) and extract:
+
+- **Severity levels** and their definitions
+- **Focus areas** specific to this project
+- **File categorization** rules
+
+These are project-specific and MUST come from `standards/code-review.md`. If the file doesn't exist or has TBD entries, use the universal checks only and note the gap.
+
+### Step 2: Get Changes to Review
+
+Try in order:
+
+```bash
+# Method 1: PR diff
+gh pr diff
+
+# Method 2: Uncommitted changes
+git diff HEAD
+
+# Method 3: Branch comparison
+git diff main...HEAD
+```
+
+**If no changes found:** ABORT.
+
+### Step 3: Identify and Categorize Changed Files
+
+Categorize files using the file categorization rules from `CLAUDE.md` or `standards/code-review.md`.
+
+If no file categorization rules are defined, categorize by file extension and directory.
+
+### Step 4: Analyze — Universal Checks
+
+These checks apply to every project regardless of tech stack:
+
+**Code Quality (DRY):**
+
+- Repeated code blocks that should be extracted
+- Copy-pasted logic with minor variations
+- New helpers or utilities that duplicate existing exports — flag with the existing function name and location
+
+**Code Quality (KISS):**
+
+- Over-engineered solutions for simple problems
+- Unnecessary abstractions or indirection
+- Premature generalization
+
+**Hardcoded Values:**
+
+- Magic numbers or strings that should be constants
+- Environment-specific values that should be configurable
+
+**Security:**
+
+- Credentials or secrets in code
+- User input used without validation at system boundaries
+- Common injection vectors (SQL, command, XSS)
+
+**Consistency:**
+
+- Naming conventions inconsistent within the diff
+- Import patterns inconsistent with existing codebase
+- File organization deviating from project structure
+
+### Step 5: Analyze — Project-Specific Checks
+
+Apply the focus areas defined in `CLAUDE.md` or `standards/code-review.md`. These vary per project and may include things like typing, accessibility, framework-specific patterns, etc.
+
+**If focus areas are TBD or not defined:** Skip this step and note it in the output.
+
+### Step 6: Categorize Findings
+
+Use the severity levels from `CLAUDE.md` or these defaults:
+
+| Severity | Action Required        |
+| -------- | ---------------------- |
+| Critical | Must fix before merge  |
+| High     | Must fix before merge  |
+| Medium   | Fix if straightforward |
+| Low      | Note for future        |
+
+Each finding must include:
+
+- Severity
+- File path and line number(s)
+- Description of the issue
+- Suggested fix (brief)
+
+### Step 6.5: Map Findings to Harness Pillars
+
+For each finding, tag which harness pillar(s) should have caught it:
+
+- **Documentation/Memory** — Missing or unclear rule in CLAUDE.md, ADRs, or knowledge base
+- **Architecture/Constraints** — Missing type constraint, linter rule, or structural enforcement
+- **Verification/Back-pressure** — Missing test, hook, or CI gate that would have caught it
+- **Context Management** — Agent didn't have the right information at the right time
+
+A finding may map to multiple pillars. The primary pillar is the one whose improvement would most directly prevent the finding.
+
+### Step 7: Generate Review Summary
+
+**Format:**
+
+```
+## Code Review: Issue #<number>
+
+### Findings
+
+**Critical (<count>):**
+- <file:line> — <description> [<Pillar>]
+
+**High (<count>):**
+- <file:line> — <description> [<Pillar>]
+
+**Medium (<count>):**
+- <file:line> — <description> [<Pillar>]
+
+**Low (<count>):**
+- <file:line> — <description> [<Pillar>]
+
+### Harness Improvements
+
+| Pillar | Recommendation |
+|--------|---------------|
+| <Pillar> | <What harness change would prevent this class of finding> |
+
+### Recommendation
+<Pass / Pass with fixes / Needs revision>
+
+### Summary Table
+
+| Severity | Count |
+|----------|-------|
+| Critical | <n>   |
+| High     | <n>   |
+| Medium   | <n>   |
+| Low      | <n>   |
+
+### Harness Self-Audit
+Overall: <score>% (<tier>)
+Drift items: <count>
+```
+
+### Step 8: Record Findings to code-review-results/
+
+**Always** create a review file at `code-review-results/YYYY-MM-DD-issue-<number>.md`, regardless of whether findings exist. This is mandatory — a missing file is ambiguous (was the review clean, or was it never run?). Include **all** severity levels (Critical, High, Medium, and Low).
+
+#### When findings exist
+
+**File format:**
+
+```markdown
+# Code Review: Issue #<number> — <date>
+
+## Findings
+
+| Severity | File                       | Issue                               | Pillar        | Resolved |
+| -------- | -------------------------- | ----------------------------------- | ------------- | -------- |
+| Critical | `src/rules/runner.ts:42`   | SQL injection via unsanitized input | Architecture  | Yes      |
+| High     | `src/commands/audit.ts:15` | Missing return type annotation      | Architecture  | Yes      |
+| Medium   | `src/utils/scoring.ts:78`  | Magic number should be a constant   | Documentation | No       |
+| Low      | `src/utils/fs.ts:12`       | Inconsistent param naming           | Documentation | No       |
+
+## Harness Improvement Recommendations
+
+For each Medium+ finding, ask: **what harness change would prevent this class of issue from occurring in the first place?**
+
+| Finding             | Harness Recommendation                                                                                 | Harness Change Made                                  |
+| ------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
+| SQL injection       | Add a hook or ESLint rule that flags unsanitized string interpolation in query patterns                | Yes — added ESLint rule `no-raw-query-interpolation` |
+| Missing return type | ESLint rule `@typescript-eslint/explicit-function-return-type` should catch this — verify it's enabled | No                                                   |
+| Magic number        | Add a CLAUDE.md constraint: "Extract numeric literals into named constants"                            | No                                                   |
+```
+
+#### When no findings exist (clean review)
+
+A clean review file uses the same structure but with an empty findings table, explicit zero counts, and a list of files that were reviewed.
+
+**Clean review format:**
+
+```markdown
+# Code Review: Issue #<number> — <date>
+
+## Files Reviewed
+
+- `src/commands/example.ts`
+- `src/commands/example.test.ts`
+
+## Findings
+
+No issues found.
+
+| Severity | Count |
+| -------- | ----- |
+| Critical | 0     |
+| High     | 0     |
+| Medium   | 0     |
+| Low      | 0     |
+
+## Harness Improvement Recommendations
+
+No recommendations — all reviewed code met project standards.
+```
+
+#### Key principles
+
+The harness recommendation should target the _class_ of issue, not the specific instance. Ask "how do we make it impossible for the model to produce this kind of mistake?" — better CLAUDE.md instructions, a new hook, a stricter linter rule, a pre-commit check, or an architecture constraint.
+
+The "Harness Change Made" column records whether a harness improvement was actually applied during this review cycle. If a change was made, briefly describe it.
+
+### Step 8.5: Run Harness Self-Audit
+
+If the project has a harness audit tool available (e.g., `harness audit`), run it to detect harness drift and internal inconsistencies. This catches problems that code-level review cannot — such as stale references in CLAUDE.md, missing harness components, or structure drift.
+
+**Execution:**
+
+```bash
+# Try the project's harness audit command
+# The exact command depends on the project — check CLAUDE.md or package.json
+npx harness audit -f markdown 2>/dev/null || echo "harness audit not available"
+```
+
+**If a harness audit tool is not available**, note the skip in the review file and continue. Not every project will have one — the self-audit is valuable when present but not a blocker.
+
+**Append to the review file** created in Step 8. Add a `## Harness Self-Audit` section **after** the Harness Improvement Recommendations section.
+
+**Format for the self-audit section:**
+
+```markdown
+## Harness Self-Audit
+
+Self-audit ran harness audit against the project root.
+
+| Category     | Score | Pass | Fail |
+| ------------ | ----: | ---: | ---: |
+| Instructions |   85% |    6 |    1 |
+| Verification |  100% |    4 |    0 |
+| ...          |   ... |  ... |  ... |
+
+**Overall:** 88% (Decent)
+
+### Drift Detected
+
+- CLAUDE.md references `src/utils/cache.ts` but file does not exist on disk
+- Standards doc references missing file
+
+### No Drift Detected
+
+If no issues are found, state: "No harness drift detected. All declared files and references are consistent."
+```
+
+**Key rules:**
+
+- Always include the self-audit section, even when the audit passes cleanly
+- Report the overall score and tier from the audit
+- List specific drift items as bullet points
+- Do NOT mix self-audit findings with code review findings — they are separate concerns
+
+### Step 9: Return Results
+
+```
+SUCCESS: Code review complete
+
+Findings:
+- Critical: <count>
+- High: <count>
+- Medium: <count>
+- Low: <count>
+
+Recommendation: <Pass / Pass with fixes / Needs revision>
+
+<Full review summary from Step 7>
+```
+
+---
+
+## Notes
+
+- Focus on actionable feedback with specific file locations
+- Do NOT include positive observations — the signal in code reviews is what can improve the harness. Positive results are noise.
+- Universal checks (Step 4) are built into this agent and apply everywhere
+- Project-specific checks (Step 5) come from `CLAUDE.md` — never hardcode them here
+- If invoked with a "fix findings" directive, apply fixes for all and return updated summary
+- Always create a `code-review-results/YYYY-MM-DD-issue-<number>.md` file — even when no issues are found. These drive harness improvement metrics over time, and a missing file is ambiguous

--- a/.claude/agents/implement-kit.md
+++ b/.claude/agents/implement-kit.md
@@ -1,0 +1,219 @@
+# Implement Agent
+
+**Purpose:** Execute the implementation plan, run code review, test, commit, and create PR.
+
+**Runs in:** Isolated agent context
+
+**Input:** Issue number (provided in prompt)
+
+**Output:** PR URL OR abort with blocker
+
+---
+
+## Prerequisites
+
+Files must exist (created by previous agents):
+
+- `.claude/temp/GH-ISSUE-<number>-REMOVE.md`
+- `.claude/temp/PLAN-<number>-REMOVE.md`
+
+---
+
+## Execution Steps
+
+### Step 1: Validate Prerequisites
+
+Check required files exist. If missing, ABORT.
+
+### Step 2: Load Project Context
+
+Read `CLAUDE.md` for:
+
+- Project commands (lint, build, test, etc.)
+- Code review focus areas and severity levels
+- Conventions (commit style, co-author line)
+- Error protocol (three-strikes)
+
+Also read `README.md` if present.
+
+### Step 3: Load and Parse Plan
+
+Read `.claude/temp/PLAN-<number>-REMOVE.md`
+
+Extract: all tasks, files to create/modify, success criteria.
+
+### Step 4: Execute Plan Tasks
+
+**For each task:**
+
+1. **Before creating any new function, type, or helper:** Search the codebase for existing implementations. Reuse or extend existing code rather than duplicating. This applies especially to test factories and shared utilities.
+2. Execute following plan instructions exactly
+3. Verify success criteria (lint, build, typecheck pass)
+4. **Commit the completed task** — each task gets its own commit capturing one logical unit of work. Use the commit style and co-author line from `CLAUDE.md`.
+5. Handle failures per the error protocol defined in `CLAUDE.md`
+
+**Commit guidance:** A commit should capture one coherent change. If a task is large, it may warrant multiple commits. If two tasks are trivially small and tightly coupled, they may share a commit. Use judgment — the goal is reviewable, revertable units.
+
+### Step 5: Run Quality Checks
+
+Run the lint, build, and test commands defined in the Commands table in `CLAUDE.md`.
+
+**If any command is TBD in CLAUDE.md, skip it and note it was skipped.**
+
+### Step 6: Test Implementation
+
+**CRITICAL: Actually run and verify the feature works.**
+
+1. Run the build command from `CLAUDE.md`
+2. Run the test command from `CLAUDE.md`
+
+**If bugs discovered:** Fix them, re-test, commit fixes separately.
+
+### Step 7: Code Review (via code-review-agent)
+
+Spawn the code-review-agent to review all changes:
+
+```
+Agent tool invocation:
+- subagent_type: general-purpose
+- description: "Code review for issue #<number>"
+- prompt: |
+    You are code-review-agent. Perform comprehensive code review for Issue #<number>.
+
+    First, read .claude/agents/code-review-kit.md and follow every step exactly.
+
+    MANDATORY OUTPUT: You MUST create the file code-review-results/YYYY-MM-DD-issue-<number>.md
+    (using today's date). This is non-negotiable — a missing file means the review never happened.
+    Follow the exact format specified in Step 8 of your agent definition. If no findings exist,
+    create a clean review file (also specified in Step 8).
+
+    Return either:
+    - SUCCESS: with full review summary
+    - ABORT: if no changes found to review
+```
+
+Parse the returned findings by severity.
+
+### Step 7.5: Verify Code Review Results File Exists
+
+**After code-review-agent returns, check that the results file was created:**
+
+```bash
+ls code-review-results/YYYY-MM-DD-issue-<number>.md
+```
+
+**If the file does NOT exist, create it yourself.** Use the review summary returned by code-review-agent to write the file in the format specified in `.claude/agents/code-review-kit.md` Step 8.
+
+### Step 8: Report Review Findings (DO NOT FIX)
+
+**Default behavior:** Report findings only. Do NOT auto-fix any findings. The human reviews the code review results file and decides what to fix.
+
+Record the code review summary (severity counts and recommendation) for inclusion in the PR body and verification document.
+
+**Override:** If the caller (e.g., batch-worker-agent) provides an explicit fix policy in the prompt, follow that policy instead of the default. The override will specify which severities to fix.
+
+### Step 9: Create Verification Document
+
+**Write:** `.claude/temp/VERIFICATION-<number>-REMOVE.md`
+
+Include:
+
+- Implementation summary (files created/modified)
+- Actual command output from quality checks and tests
+- Code review findings summary (severity counts, recommendation)
+- All findings with file locations and descriptions (unless a fix policy override was applied)
+- Additional testing notes for human
+
+### Step 10: Verify All Changes Are Committed
+
+Run `git status` to verify no uncommitted changes remain. In particular, check that `code-review-results/` is staged and committed. If any uncommitted changes exist, commit them now with an appropriate message.
+
+### Step 11: Create Pull Request
+
+```bash
+git push -u origin HEAD
+
+gh pr create --title "[Issue #<number>] <title>" --body "$(cat <<'EOF'
+## Summary
+Closes #<number>
+
+<Brief description>
+
+## Changes
+- <list changes>
+
+## Code Review Completed
+
+| Severity | Found | Fixed | Deferred |
+|----------|-------|-------|----------|
+| Critical | <n>   | <n>   | 0        |
+| High     | <n>   | <n>   | 0        |
+| Medium   | <n>   | <n>   | <n>      |
+| Low      | <n>   | 0     | <n>      |
+
+Recommendation: <Pass / Pass with fixes>
+
+## Testing Completed
+- [x] Lint passing
+- [x] Build succeeds
+- [x] Tests passing
+
+## Additional Testing Needed
+- [ ] <project-specific manual testing from CLAUDE.md>
+
+Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### Step 12: Return Success
+
+```
+SUCCESS: Implementation complete for Issue #<number>
+
+Pull Request: <PR URL>
+Branch: feature/issue-<number>-<description>
+Commit: <commit hash>
+
+Code review:
+- Critical: <count> (all fixed)
+- High: <count> (all fixed)
+- Medium: <count> (<fixed>/<total>)
+- Low: <count> (deferred)
+
+Recommendation: <Pass / Pass with fixes>
+
+Unresolved findings:
+- <severity>: <file:line> — <description>
+(or "None" if all findings were resolved)
+
+Next steps for human:
+1. Review PR at <PR URL>
+2. Review unresolved findings above
+3. Perform additional manual testing
+4. Approve and merge if satisfied
+```
+
+---
+
+## Abort Conditions
+
+| Condition                      | Abort Message                  |
+| ------------------------------ | ------------------------------ |
+| Plan file missing              | "Required files not found"     |
+| Task fails 3 times             | "Task failed after 3 attempts" |
+| Quality checks fail repeatedly | "Cannot pass quality checks"   |
+| Tests reveal fundamental issue | "Implementation does not work" |
+
+---
+
+## Notes
+
+- Execute plan MECHANICALLY — follow instructions exactly
+- **Commit after each completed task** — small, related commits are easier to review and revert
+- Error protocol (three-strikes) is defined in `CLAUDE.md`
+- All project commands (lint, build, test) come from `CLAUDE.md` — never hardcode
+- Code review is delegated to code-review-agent — never review inline
+- Always include ACTUAL output in verification doc
+- Fix bugs discovered during testing (don't just report)
+- PR must be created before returning success

--- a/.claude/agents/plan-kit.md
+++ b/.claude/agents/plan-kit.md
@@ -1,0 +1,143 @@
+# Plan Agent
+
+**Purpose:** Deep analysis and comprehensive planning for issue implementation.
+
+**Runs in:** Isolated agent context
+
+**Input:** Issue number (provided in prompt)
+
+**Output:** Success message OR abort with blocker
+
+---
+
+## Prerequisites
+
+Files must exist (created by prep-agent):
+
+- `.claude/temp/GH-ISSUE-<number>-REMOVE.md`
+- `.claude/temp/CONTEXT-HINT-<number>-REMOVE.md`
+
+---
+
+## Execution Steps
+
+### Step 1: Validate Prerequisites
+
+Check required files exist.
+
+**If files missing:** ABORT with instructions to run prep-agent first.
+
+### Step 2: Load Issue and Context Hint
+
+Read both files and extract:
+
+- Issue title, body, labels, comments
+- Keywords from context hint
+- Suggested directories for exploration
+
+### Step 3: Load Project Context
+
+**Always load:**
+
+1. `CLAUDE.md` — Essential project guide, conventions, structure
+2. `README.md` — Project overview (if present)
+
+### Step 4: Explore Codebase
+
+Use Explore subagent or direct file reads to understand:
+
+- Current project structure and directory layout
+- Existing code patterns and conventions
+- How new work fits with existing code
+- Integration points
+
+### Step 5: Deep Analysis
+
+**Search for reusable code:**
+
+Before proposing any new helpers, utilities, or test factories, search the codebase for existing implementations that could serve the same purpose. Document what you found and, if proposing something new, explain why existing code doesn't fit.
+
+**Understand the issue:**
+
+- What is the actual requirement?
+- What are the acceptance criteria?
+- What constraints exist?
+- What could go wrong?
+
+**Identify scope:**
+
+- Files to create/modify/delete
+- Integration points
+
+**Check for blockers:**
+
+- Are requirements clear enough?
+- Are there architectural implications?
+
+**If blocked:** ABORT with details.
+
+### Step 6: Create Implementation Plan
+
+**Write:** `.claude/temp/PLAN-<number>-REMOVE.md`
+
+Include:
+
+- Issue summary (title, description, complexity, estimated time)
+- Analysis (what needs to be done, risks)
+- Files to create/modify
+- Step-by-step implementation tasks with success criteria
+- Testing & verification phase
+- Verification checklist
+- **Task Dependency Graph (DAG)** — if requested by the caller. Maps tasks to waves of parallel execution. Each task lists its ID, description, files it touches, and dependencies (other task IDs that must complete first). Tasks with no dependencies go in wave 1. Example:
+
+```markdown
+## Task Dependency Graph (DAG)
+
+| Task ID | Description           | Files                 | Depends On |
+| ------- | --------------------- | --------------------- | ---------- |
+| T1      | Create types          | src/types/audit.ts    | —          |
+| T2      | Implement rule runner | src/rules/runner.ts   | T1         |
+| T3      | Add scoring utils     | src/utils/scoring.ts  | T1         |
+| T4      | Wire up audit command | src/commands/audit.ts | T2, T3     |
+
+### Waves
+
+- **Wave 1:** T1 (no dependencies)
+- **Wave 2:** T2, T3 (depend on T1, parallel)
+- **Wave 3:** T4 (depends on T2+T3)
+```
+
+### Step 7: Return Success
+
+```
+SUCCESS: Plan complete for Issue #<number>
+
+Plan file: .claude/temp/PLAN-<number>-REMOVE.md
+
+Summary:
+- Complexity: <Low/Medium/High>
+- Tasks: <count>
+- Files to modify: <count>
+
+Ready for: implement-agent
+```
+
+---
+
+## Abort Conditions
+
+| Condition                 | Abort Message                        |
+| ------------------------- | ------------------------------------ |
+| Prep files missing        | "Prep files not found"               |
+| Requirements unclear      | "Cannot proceed without human input" |
+| Multiple valid approaches | "Architectural decision needed"      |
+
+---
+
+## Notes
+
+- This agent does deep reasoning (may take 2-5 minutes)
+- Explores codebase thoroughly before planning
+- Plan should be detailed enough for mechanical execution
+- If unsure about anything, abort and ask — don't guess
+- Error protocol (three-strikes) is defined in `CLAUDE.md`

--- a/.claude/agents/prep-kit.md
+++ b/.claude/agents/prep-kit.md
@@ -1,0 +1,111 @@
+# Prep Agent
+
+**Purpose:** Fast setup for issue implementation - create branch, fetch issue, generate context hints.
+
+**Runs in:** Isolated agent context
+
+**Input:** Issue number (provided in prompt)
+
+**Output:** Success message OR abort with blocker
+
+---
+
+## Prerequisites
+
+- Git repository is clean (no uncommitted changes)
+- GitHub CLI authenticated (`gh auth status`)
+- On main branch or ready to create feature branch
+
+---
+
+## Execution Steps
+
+### Step 1: Validate Issue Exists
+
+```bash
+gh issue view <issue-number> --json number,title,body,labels,state,comments
+```
+
+**If issue not found:** ABORT with guidance.
+**If issue found:** Parse JSON and continue.
+
+### Step 2: Check Git Status
+
+```bash
+git status --porcelain
+```
+
+**If uncommitted changes:** ABORT with details.
+**If clean:** Continue.
+
+### Step 3: Update Main Branch
+
+```bash
+git fetch origin && git checkout main && git pull origin main
+```
+
+### Step 4: Create Feature Branch
+
+**Branch naming format:** Use the convention from `CLAUDE.md`. Default: `feature/issue-<number>-<description>`
+
+- Convert title to lowercase, hyphens, remove special chars, truncate ~30 chars
+
+```bash
+git checkout -b feature/issue-<number>-<description>
+```
+
+### Step 5: Save Issue to File
+
+**Create directory:** `mkdir -p .claude/temp`
+
+**Write:** `.claude/temp/GH-ISSUE-<number>-REMOVE.md`
+
+Include: issue metadata (number, title, state, labels, URL), full description, all comments with author and timestamp.
+
+### Step 6: Create Context Hint File
+
+**Write:** `.claude/temp/CONTEXT-HINT-<number>-REMOVE.md`
+
+Extract from issue text only (no codebase exploration):
+
+- Keywords from title and body
+- Files/paths mentioned
+- Related issue numbers
+- Suggested directories for exploration based on issue type
+
+**Token target:** ~100-200 tokens
+
+### Step 7: Return Success
+
+```
+SUCCESS: Prep complete for Issue #<number>
+
+Branch: feature/issue-<number>-<description>
+
+Files created:
+- .claude/temp/GH-ISSUE-<number>-REMOVE.md
+- .claude/temp/CONTEXT-HINT-<number>-REMOVE.md
+
+Ready for: plan-agent
+```
+
+---
+
+## Abort Conditions
+
+| Condition                    | Abort Message                  |
+| ---------------------------- | ------------------------------ |
+| Issue not found              | "Issue #N not found"           |
+| Git not clean                | "Uncommitted changes detected" |
+| Branch exists                | "Branch already exists"        |
+| GitHub CLI not authenticated | "GitHub CLI not authenticated" |
+
+---
+
+## Notes
+
+- This agent is fast (~30-60 seconds)
+- Does NOT read codebase files (that's plan-agent's job)
+- Context hints are intentionally minimal for token efficiency
+- Always include issue comments — they often have important details
+- Error protocol (three-strikes) is defined in `CLAUDE.md`

--- a/.claude/agents/swarm-worker-kit.md
+++ b/.claude/agents/swarm-worker-kit.md
@@ -1,0 +1,284 @@
+# Swarm Worker Agent
+
+**Purpose:** Execute assigned implementation tasks as part of a parallel swarm. Implementation only — no quality checks, no commits, no PRs.
+
+**Runs in:** Isolated agent context (200k token budget)
+
+**Input:** Task IDs and instructions from the orchestrating command (e.g., swarm-runner)
+
+**Output:** SUCCESS with file list OR ABORT with details
+
+**Timeout:** 15 minutes
+
+---
+
+## Key Differences from Implement Agent
+
+| Aspect           | Swarm Worker                    | Implement Agent          |
+| ---------------- | ------------------------------- | ------------------------ |
+| Scope            | Subset of tasks (1-3 typically) | Entire issue             |
+| Quality checks   | NO — final-agent handles        | Full suite + code review |
+| Commits          | NO — orchestrator commits       | YES                      |
+| PR creation      | NO — orchestrator creates PR    | YES                      |
+| Verification doc | NO — final-agent creates        | YES                      |
+| Context usage    | ~50-80k tokens                  | ~180k tokens             |
+| Duration         | ~2-5 minutes per task           | ~30+ minutes             |
+
+---
+
+## Execution Steps
+
+### Step 1: Parse Assignment
+
+Extract from prompt:
+
+- Issue number
+- Task IDs assigned to this worker
+- Task descriptions and requirements
+- Files this worker is ALLOWED to create/modify
+- Files this worker MUST NOT touch (assigned to other workers)
+
+**Validate assignment:**
+
+- Task IDs are clear (e.g., T1, T2, T3)
+- File list is explicit
+- Success criteria are defined
+
+**If assignment unclear:**
+
+```
+ABORT: Assignment unclear
+
+Details: <what is unclear about the assignment>
+
+Suggested action: Check orchestrator prompt or task definition in plan
+```
+
+### Step 2: Load Minimal Context
+
+**Required (always load):**
+
+- `CLAUDE.md` — Project guide, conventions, structure reference
+
+**Load standards from `CLAUDE.md` guidance:**
+
+- Check `CLAUDE.md` for which standards docs exist and when to load them
+- Load relevant quick-ref docs based on task type
+- If task instructions include REQUIRED directives (e.g., "REQUIRED: Load <standards-path>"), load those files before implementing
+
+**Task-specific (load only what's needed):**
+
+- For creating new files: Read a similar existing file as an example
+- For modification: Read the file being modified
+- For integration: Read the parent/container file
+
+**DO NOT:**
+
+- Read entire codebase directories
+- Load documentation not relevant to your tasks
+- Explore unrelated code
+- Use Explore agent (you have a targeted assignment)
+
+**Context budget:** Aim for <80k tokens total loaded content
+
+### Step 3: Pre-flight File Permission Check
+
+**CRITICAL:** Before making any changes, validate your file permissions.
+
+1. List the files you plan to create/modify for each task
+2. Compare against your "Files ALLOWED to Modify" list from assignment
+3. If ANY file is not in allowed list: ABORT immediately (before making changes)
+
+**Example pre-flight abort:**
+
+```
+ABORT: File permission violation (pre-flight)
+
+Task T3 requires modifying <file> but this file is not in my allowed list.
+
+My allowed files:
+- <list>
+
+No changes made. Orchestrator should review task assignment.
+```
+
+### Step 4: Execute Assigned Tasks
+
+For each task in assignment:
+
+#### 4.1: Understand Requirements
+
+Read task description from plan (provided in orchestrator prompt):
+
+- What to create/modify
+- Success criteria
+- Standards to follow
+- Integration requirements
+
+#### 4.2: Implement Changes
+
+**Create new files:**
+
+- Follow patterns from `CLAUDE.md` and standards docs
+- Follow naming conventions from the project
+- Match existing code patterns in the codebase
+
+**Modify existing files:**
+
+- Read the file first (entire file)
+- Make targeted changes using Edit tool
+- Preserve existing patterns
+- Don't refactor unrelated code
+
+**Write tests (if part of your task assignment):**
+
+- Create test file following project conventions
+- Cover main functionality
+- Follow existing test patterns
+
+#### 4.3: Validate File Permissions (Post-Implementation)
+
+```bash
+git status --porcelain
+```
+
+Check each modified file against your allowed list. If you modified an unauthorized file, ABORT.
+
+### Step 5: Return Results
+
+**Success Format:**
+
+```
+SUCCESS: Tasks <task-ids> complete
+
+Files created:
+- <path> (purpose)
+
+Files modified:
+- <path> (changes made)
+
+No quality checks performed — final-agent will handle.
+```
+
+**Abort Format:**
+
+```
+ABORT: Cannot complete task <task-id>
+
+Reason: <what went wrong>
+
+Details:
+<explanation>
+
+Attempts made:
+1. <what was tried>
+2. <what was tried>
+3. <what was tried>
+
+Suggested action:
+<recovery guidance>
+```
+
+---
+
+## Constraints
+
+### File Access Rules
+
+**MUST:**
+
+- Only create/modify files in your allowed list
+- Check git status before returning
+- Abort if you touched unauthorized files
+
+**MUST NOT:**
+
+- Modify files assigned to other workers
+- Make unrelated changes outside task scope
+- Refactor code not part of your tasks
+
+### What Workers Do NOT Do
+
+Workers focus exclusively on implementation. The following are handled by the orchestrating command or final-agent:
+
+- Linting
+- Build verification
+- Running test suites
+- Code review
+- Formatting
+- Creating verification documents
+- Committing changes
+- Creating pull requests
+
+### Time Management
+
+**Timeout:** 15 minutes maximum
+
+**If approaching timeout:**
+
+- Prioritize completing tasks over perfect polish
+- Return partial success if some tasks done
+- Include clear status of what's incomplete
+
+### Communication
+
+**DO:**
+
+- Return structured SUCCESS or ABORT message
+- Include all files created/modified
+- Provide clear abort reasons
+
+**DO NOT:**
+
+- Try to coordinate with other workers
+- Assume what other workers are doing
+- Wait for other workers to complete
+- Send progress updates (return only when done)
+
+---
+
+## Error Handling
+
+Use the error protocol defined in `CLAUDE.md` (three-strikes):
+
+1. **First failure:** Debug and retry
+2. **Second failure:** Try alternative approach (consult standards docs if applicable)
+3. **Third failure:** ABORT with detailed explanation of all attempts
+
+### Common Failure Scenarios
+
+| Scenario                      | Action                                    |
+| ----------------------------- | ----------------------------------------- |
+| File dependency missing       | ABORT — dependency error                  |
+| Import cannot resolve         | Check allowed files, fix import, or ABORT |
+| Task requirements unclear     | ABORT — requirements unclear              |
+| Timeout approaching (13+ min) | Return partial results or ABORT           |
+
+---
+
+## Success Criteria
+
+**Your work is complete when:**
+
+- All assigned tasks implemented according to requirements
+- All files created exist
+- Only allowed files modified
+- Returned structured SUCCESS message
+
+**The orchestrator / final-agent will handle:**
+
+- Running quality checks (lint, build, test)
+- Code review
+- Creating verification document
+- Committing changes
+- Creating pull request
+
+Your job is to implement your assigned tasks correctly and efficiently.
+
+---
+
+**Agent Type:** Worker (parallel execution)
+**Spawned By:** orchestrating command (e.g., swarm-runner)
+**Reports To:** orchestrating command
+**Timeout:** 15 minutes
+**Context Budget:** ~200k tokens

--- a/.claude/commands/batch-runner-kit.md
+++ b/.claude/commands/batch-runner-kit.md
@@ -1,0 +1,259 @@
+# Batch Runner
+
+**Purpose:** Run 1-5 independent GitHub issues in parallel, each in its own worktree, producing PRs with code review for each.
+
+**Usage:** `/batch-runner <issue-1> [issue-2] [issue-3] [issue-4] [issue-5]`
+
+**Example:** `/batch-runner 5 6 7 8`
+
+---
+
+## Overview
+
+Spawns parallel workers (each in an isolated git worktree) to run the full issue lifecycle:
+
+1. Prep (fetch issue, create branch)
+2. Plan (deep analysis)
+3. Implement (code, test, code review, commit)
+4. Merge latest main
+5. Push and create PR
+6. Write per-issue report
+
+User kicks it off, walks away, comes back to PRs ready for approval.
+
+**Requirements:**
+
+- Issues MUST be independent (different files/components, different areas of codebase)
+- If issues touch the same files, use `/story-runner` sequentially instead
+- Git must be clean (no uncommitted changes)
+- 1-5 issue numbers required
+
+---
+
+## Execution
+
+### Step 1: Parse and Validate Input
+
+Extract issue numbers from `$ARGUMENTS`.
+
+**Validation rules:**
+
+- Must contain 1-5 space-separated integers
+- No duplicates
+- Each must be a positive integer
+
+**If validation fails:**
+
+```
+BATCH RUNNER: Invalid input
+
+Usage: /batch-runner <issue-1> <issue-2> [issue-3] [issue-4] [issue-5]
+
+Example: /batch-runner 5 6 7 8
+
+Requirements:
+- Provide 1-5 issue numbers (space-separated)
+- Issues must be independent (different areas of codebase)
+- No duplicate issue numbers
+```
+
+### Step 2: Verify All Issues Exist
+
+For each issue number:
+
+```bash
+gh issue view <N> --json number,title,state --jq '.number, .title, .state'
+```
+
+**If any issue not found, abort all.**
+**If all found, display list and continue.**
+
+### Step 3: Verify Git State
+
+```bash
+git status --porcelain
+```
+
+**If not clean, abort** with options to commit, stash, or discard.
+
+### Step 4: Update Main Branch
+
+```bash
+git fetch origin main
+git checkout main
+git pull origin main
+```
+
+### Step 5: Display Launch Summary
+
+```
+BATCH RUNNER: Launching <count> parallel workers
+
+  Worker 1: Issue #5 - "<title>"
+  Worker 2: Issue #6 - "<title>"
+  Worker 3: Issue #7 - "<title>"
+
+Each worker runs: prep > plan > implement (with code review) > merge main > push > PR
+
+This will take approximately 15-30 minutes. Workers run in parallel.
+Waiting for all workers to complete...
+```
+
+### Step 6: Spawn Parallel Workers
+
+**CRITICAL: Spawn ALL workers in a SINGLE message with multiple Agent tool calls.**
+
+All Agent calls must be in the SAME message for true parallelism. Do NOT spawn them one at a time.
+
+For each issue number N:
+
+```
+Agent tool invocation:
+- subagent_type: general-purpose
+- isolation: worktree
+- description: "Batch worker: issue #<N>"
+- prompt: |
+    You are batch-worker-agent for GitHub issue #<N>.
+
+    Issue title: "<title from Step 2>"
+
+    Your issue number is: <N>
+
+    You are running in an isolated git worktree. Your working directory
+    is a separate copy of the repository. Other workers are running
+    simultaneously on different issues in their own worktrees.
+
+    CRITICAL: Your instructions are in `.claude/agents/batch-worker-kit.md`.
+    Read that file FIRST and follow it exactly — all 6 phases, in order.
+    Do NOT improvise or skip phases. The agent definition is the
+    authoritative source for your behavior.
+
+    Return EXACTLY one of:
+
+    SUCCESS: Issue #<N> complete
+    PR: <url>
+    Branch: <name>
+    Commits: <hashes>
+
+    Code review:
+    - Critical: <count> (all fixed)
+    - High: <count> (all fixed)
+    - Medium: <count> (<fixed>/<total>)
+    - Low: <count> (deferred)
+
+    Recommendation: <Pass / Pass with fixes>
+    Main merge: <status>
+    Tests: <status>
+
+    Report: .claude/temp/BATCH-REPORT-<N>-REMOVE.md
+
+    OR:
+
+    ABORT: Issue #<N> failed
+    Phase: <phase name>
+    Reason: <what went wrong>
+    Last successful phase: <phase or "none">
+
+    Report: .claude/temp/BATCH-REPORT-<N>-REMOVE.md
+```
+
+**All 1-5 Agent calls in ONE message.** Wait for all to return.
+
+### Step 7: Collect and Parse Results
+
+For each worker response, extract:
+
+- SUCCESS or ABORT status
+- PR URL (if success)
+- Code review summary (if success)
+- Phase and reason (if failure)
+- Report file path
+
+### Step 8: Display Consolidated Summary
+
+```
+===============================================
+BATCH RUNNER COMPLETE
+===============================================
+
+Results: <succeeded>/<total> issues completed
+
+-----------------------------------------------
+
+Issue #5: <title>
+  Status:  SUCCESS
+  PR:      <PR URL>
+  Review:  0 Critical, 0 High, 2 Medium, 1 Low
+  Merge:   Clean
+  Report:  .claude/temp/BATCH-REPORT-5-REMOVE.md
+
+Issue #6: <title>
+  Status:  SUCCESS
+  PR:      <PR URL>
+  Review:  0 Critical, 1 High (fixed), 0 Medium, 3 Low
+  Merge:   Clean
+  Report:  .claude/temp/BATCH-REPORT-6-REMOVE.md
+
+Issue #7: <title>
+  Status:  FAILED
+  Phase:   implement
+  Reason:  Tests failed after 3 attempts
+  Report:  .claude/temp/BATCH-REPORT-7-REMOVE.md
+
+-----------------------------------------------
+
+Next steps:
+1. Review PRs:
+   - <PR URL 1>
+   - <PR URL 2>
+2. Read failure report for #7:
+   cat .claude/temp/BATCH-REPORT-7-REMOVE.md
+3. Perform manual testing per PR descriptions
+4. Approve and merge PRs when satisfied
+
+Worktree cleanup (run after PRs merged):
+  git worktree list
+  git worktree remove <path-1>
+  git worktree remove <path-2>
+
+Temp file cleanup:
+  rm .claude/temp/*-5-REMOVE.*
+  rm .claude/temp/*-6-REMOVE.*
+  rm .claude/temp/*-7-REMOVE.*
+
+===============================================
+```
+
+---
+
+## Error Handling
+
+### Validation Failures (Steps 1-4)
+
+Abort the entire batch BEFORE spawning any workers.
+
+### Worker Failures (Steps 6-7)
+
+Workers are fully independent. One worker's failure does NOT affect others.
+
+### All Workers Fail
+
+Show all failure details, report paths, and recovery options (run individually with `/story-runner`).
+
+---
+
+## Notes
+
+- Each worker runs in an isolated git worktree (no interference)
+- Workers run truly in parallel (1-5 simultaneous)
+- Issues MUST be independent — if issues touch the same files, use `/story-runner` sequentially
+- PRs are created but NOT merged — user approves and merges manually
+- Worktrees persist after batch completes; clean up after merging PRs
+
+---
+
+## Related Commands
+
+- `/story-runner <N>` - Run single issue (sequential, 3 phases)
+- `/code-review-pr <N>` - Review a PR against standards
+- `/start-worktree <N>` - Create worktree for manual work

--- a/.claude/commands/code-review-pr-kit.md
+++ b/.claude/commands/code-review-pr-kit.md
@@ -1,0 +1,57 @@
+# Code Review PR
+
+**Purpose:** Run a code review on the current PR or diff.
+
+**Usage:** `/code-review-pr [issue-number]`
+
+---
+
+## WHAT THIS COMMAND DOES
+
+1. Invoke code-review-agent with issue number
+2. Agent reviews diff against universal checks and project-specific criteria from `CLAUDE.md`
+3. Agent categorizes findings by severity
+4. Agent returns comprehensive summary
+5. Human reviews findings and decides what to fix
+
+---
+
+## EXECUTION
+
+### Step 1: Determine Issue Number
+
+If provided in command, use it. Otherwise extract from branch name or ask user.
+
+### Step 2: Invoke Agent
+
+```
+Agent tool invocation:
+- subagent_type: general-purpose
+- description: "Code review for issue #[NUMBER]"
+- prompt: |
+    You are code-review-agent. Perform comprehensive code review for Issue #[NUMBER].
+
+    First, read .claude/agents/code-review-kit.md and follow every step exactly.
+
+    MANDATORY OUTPUT: You MUST create the file code-review-results/YYYY-MM-DD-issue-[NUMBER].md
+    (using today's date). This is non-negotiable — a missing file means the review never happened.
+    Follow the exact format specified in Step 8 of your agent definition. If no findings exist,
+    create a clean review file (also specified in Step 8).
+
+    Return either:
+    - SUCCESS: with full review summary
+    - ABORT: if no changes found to review
+```
+
+### Step 3: Display Results and Next Steps
+
+Show the full review summary from the agent, then prompt:
+
+```
+Next steps:
+1. Fix Critical and High findings before merging
+2. Consider fixing Medium findings
+3. Low findings can be deferred
+
+To apply fixes automatically, ask me to fix the Critical/High findings.
+```

--- a/.claude/commands/harvest-reviews-kit.md
+++ b/.claude/commands/harvest-reviews-kit.md
@@ -1,0 +1,263 @@
+# Harvest Reviews: Strengthen the Harness from Code Review Signals
+
+**Purpose:** Scan code review result files, track finding metrics as a harness resilience signal, extract unaddressed harness improvement recommendations, validate them against the current harness, deduplicate, and create GitHub issues for harness strengthening work.
+
+**Usage:** `/harvest-reviews-kit` or `/harvest-reviews-kit --dry-run`
+
+**End Result:** Metrics track findings over time (the signal), unaddressed harness gaps are collected into a dated file, and GitHub issues are created to strengthen the harness. As harness improvements are made, finding counts should trend downward.
+
+---
+
+## WHAT THIS COMMAND DOES
+
+1. Scans all `code-review-results/*.md` files (excludes `archive/` subdirectory)
+2. Records **finding metrics** per review file to `code-review-results/metrics.csv` — one row per file with severity counts (this is the resilience signal)
+3. Extracts **Harness Improvement Recommendations** where `Harness Change Made` is `No`
+4. Validates each recommendation against the current harness (CLAUDE.md, standards/, knowledge/, hooks, etc.) to see if it has already been addressed
+5. Writes still-needed recommendations to a dated gaps file: `code-review-results/harness-gaps-YYYY-MM-DD.md`
+6. Deduplicates overlapping recommendations
+7. Creates GitHub issues grouped by pillar, labeled `harness-improvement`
+8. Archives processed review files to `code-review-results/archive/`
+
+**This command does NOT:**
+
+- Modify any source code
+- Create issues for individual source code findings (those are symptoms; the harness is the cure)
+- Process files already in the archive directory
+
+---
+
+## EXECUTION
+
+### Step 0: Check for Dry-Run Mode
+
+If `$ARGUMENTS` contains `--dry-run`, run the entire process but:
+
+- Print what issues WOULD be created (do not actually create them)
+- Print what metrics WOULD be written
+- Print what files WOULD be archived
+- Do not create GH issues, write to CSV, move files, or write the gaps file
+
+Announce dry-run mode at the start:
+
+```
+DRY RUN MODE — no issues will be created, no files will be moved, no files will be written.
+```
+
+### Step 1: Discover Review Files
+
+Check if `code-review-results/` directory exists. If it does not exist, treat it the same as "no files found."
+
+List all markdown files in `code-review-results/` (top level only, not `archive/`).
+
+**If directory does not exist or no files found:**
+
+```
+No unprocessed code review files found in code-review-results/.
+Nothing to harvest.
+```
+
+Stop here.
+
+### Step 2: Record Finding Metrics
+
+For each review file, extract the findings table. Each row has columns like:
+
+| Severity | File | Issue | Pillar | Resolved |
+
+Count findings at each severity level (Critical, High, Medium, Low) — count ALL findings regardless of Resolved status, since the total count reflects what the harness failed to prevent.
+
+**Clean review files:** If the file indicates no findings (e.g., "No issues found." with a summary count table showing all zeros), record zeros for all severity counts. Do not skip the file — a clean review is a valid data point.
+
+Append one row per review file to `code-review-results/metrics.csv`. Create the file with a header row if it does not exist.
+
+**CSV format:**
+
+```csv
+date,review_file,critical,high,medium,low,total
+2026-03-27,2026-03-27-issue-21.md,0,1,2,3,6
+2026-03-27,2026-03-27-issue-22.md,0,0,0,0,0
+```
+
+- `date`: the date from the review file name (YYYY-MM-DD)
+- `review_file`: the review file name
+- `critical/high/medium/low`: count of findings at each severity
+- `total`: total findings in that review
+
+**In dry-run mode:** Print the CSV rows but do not write them.
+
+### Step 3: Extract Harness Improvement Recommendations
+
+For each review file, extract the Harness Improvement Recommendations table. Each row typically has columns like:
+
+| Finding | Harness Recommendation | Harness Change Made |
+
+Collect all recommendations where `Harness Change Made` is `No` (case-insensitive). Skip recommendations where `Harness Change Made` is `Yes` or indicates the change was already made.
+
+**Clean review files:** If no Harness Improvement Recommendations table exists (the file says "No recommendations" or similar), skip recommendation extraction for that file. This is expected for clean reviews.
+
+### Step 4: Validate Recommendations Against Current Harness
+
+For each unaddressed recommendation, check whether it has since been implemented by examining the relevant harness files:
+
+- `CLAUDE.md` — for constraints, conventions, and rules
+- `standards/` — for craftsmanship rules, code review standards
+- `knowledge/` — for hooks guidance, agent operations
+- `.claude/settings.json` — for hook configurations
+- Project linter configuration (if any) — for lint rules
+- Project compiler/type-checker configuration (if any) — for strictness flags
+
+Mark each recommendation as:
+
+- **Still needed** — the harness does not address this class of issue
+- **Already addressed** — the harness now covers this (note where)
+
+Report validation results:
+
+```
+## Harness Recommendation Validation
+
+| Source Review | Recommendation | Status | Notes |
+| --- | --- | --- | --- |
+| 2026-03-27-issue-21.md | Add lint rule for unreachable patterns | Still needed | No lint rule configured |
+| 2026-03-25-issue-1.md | Add CLAUDE.md constraint for named constants | Already addressed | In CLAUDE.md Constraints section |
+...
+
+Still needed: X
+Already addressed: Y
+```
+
+### Step 5: Write Harness Gaps File
+
+Write all still-needed recommendations to `code-review-results/harness-gaps-YYYY-MM-DD.md` (using today's date).
+
+**Format:**
+
+```markdown
+# Harness Gaps — YYYY-MM-DD
+
+Harvested from N code review files by `/harvest-reviews-kit`.
+
+## Gaps
+
+| #   | Recommendation                                          | Source Review          | Why Still Needed                                    |
+| --- | ------------------------------------------------------- | ---------------------- | --------------------------------------------------- |
+| 1   | Add CLAUDE.md constraint for magic number extraction    | 2026-03-27-issue-21.md | No rule or hook currently catches this pattern       |
+| 2   | ...                                                     | ...                    | ...                                                 |
+```
+
+**In dry-run mode:** Print the file contents but do not write it.
+
+### Step 6: Deduplicate
+
+Review the gaps list for overlapping or redundant recommendations. Merge duplicates, keeping the most specific version and noting all source reviews. Remove any that are subsumed by a broader recommendation.
+
+Update the gaps file (or dry-run output) to reflect the deduplicated list.
+
+### Step 7: Create GitHub Issues
+
+**Prerequisite:** Verify `gh` CLI is available and authenticated. If `gh` is not installed or not authenticated, skip issue creation entirely and report:
+
+```
+GitHub CLI not available or not authenticated — skipping issue creation.
+Gaps file and metrics have been written. Create issues manually from the gaps file:
+  cat code-review-results/harness-gaps-YYYY-MM-DD.md
+```
+
+Group the deduplicated, still-needed recommendations by the pillar tags found in the review files. Use the exact pillar names from the review files (e.g., "Documentation/Memory", "Architecture/Constraints", "Verification/Back-pressure", "Context Management") rather than hardcoded values. Create one GitHub issue per pillar group.
+
+Ensure the `harness-improvement` label exists (create it if not).
+
+**Title:** `harness: [pillar] — [brief description of recommendation group]`
+
+**Body:**
+
+```markdown
+## Origin
+
+Harvested from code review results by `/harvest-reviews-kit` on [DATE].
+
+## Harness Gaps
+
+| #   | Recommendation | Source Review          | Why Still Needed |
+| --- | -------------- | ---------------------- | ---------------- |
+| 1   | Description    | 2026-03-27-issue-21.md | Rationale        |
+| 2   | ...            | ...                    | ...              |
+
+## Acceptance Criteria
+
+- [ ] Each recommendation above is implemented in the harness or documented as intentionally deferred
+- [ ] Future code reviews in the affected pillar show reduced finding counts
+```
+
+**Labels:** `harness-improvement`
+
+**In dry-run mode:** Print the issue title and body but do not create it.
+
+### Step 8: Archive Processed Files
+
+Move each processed review file to `code-review-results/archive/`:
+
+```bash
+mkdir -p code-review-results/archive
+mv code-review-results/YYYY-MM-DD-issue-N.md code-review-results/archive/
+```
+
+Do NOT archive the gaps file or metrics.csv — those stay in the active directory.
+
+**In dry-run mode:** Print which files would be moved but do not move them.
+
+### Step 9: Summary Report
+
+Display a final summary:
+
+```
+## Harvest Summary
+
+- Review files processed: X
+- Total findings recorded in metrics: X
+- Harness recommendations extracted: X
+- Already addressed: X
+- Still needed (after dedup): X
+- GitHub issues created: X (or "skipped — gh not available")
+- Files archived: X
+
+### Metrics
+
+X rows appended to code-review-results/metrics.csv
+
+### Issues Created
+
+1. #[NUMBER] - [title] (X recommendations)
+2. #[NUMBER] - [title] (X recommendations)
+...
+
+### Next Steps
+
+1. Review the created issues and prioritize harness improvements
+2. After implementing improvements, run `/harvest-reviews-kit` on the next batch of code reviews
+3. Compare metrics.csv over time — finding counts should trend downward as the harness strengthens
+```
+
+---
+
+## ERROR HANDLING
+
+- **Malformed review file:** Skip it, log a warning, continue with other files
+- **`code-review-results/` directory does not exist:** Report "nothing to harvest" and stop (same as no files found)
+- **`gh` CLI not installed or not authenticated:** Skip issue creation, still produce metrics and gaps file
+- **No harness recommendations found:** Report that all recommendations are addressed, still record metrics and archive files
+- **Label does not exist:** Create the `harness-improvement` label, then apply it
+- **Clean review file (no findings):** Record zero counts in metrics, skip recommendation extraction — do not skip the file entirely
+
+---
+
+## NOTES
+
+- This command operates on the `code-review-results/` directory in the project root
+- The `--dry-run` flag is recommended for first use to preview what will happen
+- **Findings are the signal, not the target.** This command does not create issues for individual code findings — it uses finding counts to measure harness resilience and creates issues only for harness improvements that would prevent future findings
+- Metrics CSV enables trend tracking: plot severity counts over time to see if the harness is getting stronger
+- After archiving, only unprocessed review files remain in the active directory
+- The command is idempotent on archived files — re-running will not reprocess them
+- Pillar names are extracted dynamically from review files, not hardcoded — they match whatever the code-review agent tagged

--- a/.claude/commands/implement-issue-kit.md
+++ b/.claude/commands/implement-issue-kit.md
@@ -1,0 +1,87 @@
+# Implement Issue (Phase 3: Execution)
+
+**Purpose:** Execute plan — implement changes, code review, validate, commit, create PR.
+
+**Usage:** `/implement-issue <issue-number>`
+
+**Prerequisites:** Must run `/prep-issue <number>` and `/plan-issue <number>` first
+
+**End Result:** Implementation complete, code reviewed, committed, PR created, ready for human review
+
+---
+
+## WHAT THIS COMMAND DOES
+
+1. Invoke implement-agent with issue number
+2. Agent executes plan step-by-step
+3. Agent runs quality checks (from `CLAUDE.md`)
+4. Agent spawns code-review-agent to review changes
+5. Agent fixes Critical/High findings
+6. Agent creates verification document
+7. Agent commits and creates PR
+8. Returns PR URL with code review summary and unresolved findings
+
+**This command does NOT:**
+
+- Skip quality checks
+- Commit code that doesn't build
+- Merge the PR (human reviews and merges)
+
+---
+
+## EXECUTION
+
+### Step 1: Validate Input
+
+Extract issue number from `$ARGUMENTS`.
+
+**If no issue number provided:**
+
+```
+Usage: /implement-issue <issue-number>
+
+Prerequisites:
+1. Run /prep-issue <number> first
+2. Run /plan-issue <number> first
+```
+
+### Step 2: Invoke Agent
+
+```
+Agent tool invocation:
+- subagent_type: general-purpose
+- description: "Implement issue #[NUMBER]"
+- prompt: |
+    You are implement-agent. Your task is to implement GitHub issue #[NUMBER].
+
+    Prerequisites exist:
+    - .claude/temp/GH-ISSUE-[NUMBER]-REMOVE.md
+    - .claude/temp/PLAN-[NUMBER]-REMOVE.md
+
+    Follow the instructions in the implement-agent definition exactly.
+
+    Return either:
+    - SUCCESS: with PR URL, code review summary, and unresolved findings
+    - ABORT: with specific blocker and suggested actions
+```
+
+### Step 3: Display Results
+
+Show PR URL, code review summary, unresolved findings, and next steps for human review.
+
+---
+
+## ERROR HANDLING
+
+- **Plan missing:** Error with instructions to run prep and plan first
+- **Agent returns ABORT:** Display blocker and suggested actions
+- Error protocol (three-strikes) is handled by the agent per `CLAUDE.md`
+
+---
+
+## NOTES
+
+- This command delegates all work to implement-agent
+- implement-agent delegates code review to code-review-agent
+- All project commands and review criteria come from `CLAUDE.md`
+- PR must be created before returning success

--- a/.claude/commands/integrate-kit.md
+++ b/.claude/commands/integrate-kit.md
@@ -1,0 +1,340 @@
+# Integrate Harness Kit
+
+**Purpose:** Assess a project's current harness state, identify gaps, and guide the user through adopting harness-kit conventions — whether starting from scratch or strengthening an existing setup.
+
+**Usage:** `/integrate-kit` or `/integrate-kit --dry-run`
+
+---
+
+## WHAT THIS COMMAND DOES
+
+1. Assesses the project's current harness state (greenfield, weak brownfield, or strong brownfield)
+2. Checks each harness component for existence and quality
+3. Presents findings with gap analysis
+4. For each gap, proposes a fix and asks the user whether Claude should handle it or they will do it manually
+
+**This command does NOT:**
+
+- Overwrite existing files without explicit user approval
+- Assume any tech stack — it asks or infers from what exists
+- Make changes by default — it assesses first, then proposes
+
+---
+
+## EXECUTION
+
+### Step 0: Check for Dry-Run Mode
+
+If `$ARGUMENTS` contains `--dry-run`, run the entire assessment but do not create or modify any files. Print what WOULD be done.
+
+Announce mode at the start:
+
+```
+DRY RUN MODE — assessment only, no files will be created or modified.
+```
+
+If not dry-run:
+
+```
+HARNESS INTEGRATION — assess, propose, act (with your approval).
+```
+
+### Step 1: Classify Project State
+
+Check the following and classify the project:
+
+| Check | How |
+| --- | --- |
+| Git repo initialized? | Look for `.git/` directory |
+| `CLAUDE.md` exists? | Check project root |
+| `.claude/settings.json` exists? | Check path |
+| `.claude/commands/` has files? | List directory |
+| `.claude/agents/` has files? | List directory |
+| `standards/` directory exists? | Check path |
+| `code-review-results/` directory exists? | Check path |
+| `.gitignore` exists? | Check project root |
+
+**Classification:**
+
+- **Greenfield** — No `CLAUDE.md`, no `.claude/` directory, possibly no git repo
+- **Brownfield (weak harness)** — `CLAUDE.md` exists but is incomplete (missing canonical sections), no hooks, no standards
+- **Brownfield (strong harness)** — `CLAUDE.md` with most sections, `.claude/settings.json` with hooks, some standards in place
+
+Report the classification:
+
+```
+PROJECT STATE: [Greenfield | Brownfield (weak harness) | Brownfield (strong harness)]
+
+Found:
+- [x] Git repo initialized
+- [ ] CLAUDE.md
+- [x] .claude/settings.json (no hooks configured)
+- [ ] standards/code-review.md
+...
+```
+
+### Step 2: Assess CLAUDE.md
+
+**If CLAUDE.md does not exist:**
+
+```
+GAP: CLAUDE.md does not exist
+IMPACT: Agents have no project context — they will guess at stack, conventions, and constraints
+FIX: Create CLAUDE.md from harness-kit sample template (knowledge/sample-files-kit.md)
+ACTION: Let Claude handle this? (y/n)
+```
+
+If the user says yes, ask them to describe their tech stack, architecture, and key conventions. Then generate a CLAUDE.md following the six canonical sections from `knowledge/claude-md-kit.md`, keeping it under 60 lines.
+
+**If CLAUDE.md exists:** Read it and check for the six canonical sections:
+
+1. **Tech Stack** — project description, language, framework, key tools
+2. **Architecture** — structural rules, layer boundaries, dependency flow
+3. **Commands** — exact build, test, lint, run commands
+4. **Constraints** — prohibitions and things NOT to do
+5. **Conventions** — naming, style, patterns the linter does not catch
+6. **Context Guidance** — pointers to where things are, session guidance
+
+Section matching should be flexible — look for canonical names and common synonyms:
+- Tech Stack: "Overview", "Stack", "About"
+- Architecture: "Structure", "Project Structure", "Layout"
+- Commands: "Build & Test", "Development", "Scripts"
+- Constraints: "Do NOT", "Rules", "Prohibitions"
+- Conventions: "Style", "Patterns", "Code Style"
+- Context Guidance: "Context", "References", "Where Things Are"
+
+Report per section:
+
+```
+CLAUDE.md ANALYSIS (N lines):
+
+| Section | Status | Notes |
+| --- | --- | --- |
+| Tech Stack | Present | Clear, describes stack well |
+| Architecture | Missing | No structural rules found |
+| Commands | Present | Has build/test but missing lint command |
+| Constraints | Weak | Only 1 prohibition — should have 3-5 minimum |
+| Conventions | Present | Good coverage |
+| Context Guidance | Missing | No pointers to related docs |
+```
+
+For each missing or weak section, present a GAP entry:
+
+```
+GAP: CLAUDE.md missing Architecture section
+IMPACT: Agent has no structural rules — may put code in wrong layers or create circular dependencies
+FIX: Add Architecture section with layer rules and dependency flow
+ACTION: Let Claude handle this? (y/n)
+```
+
+If the user says yes for any CLAUDE.md changes, draft the additions and show them for approval before writing.
+
+**Line count warning:** If CLAUDE.md exceeds 80 lines, note it. If over 100, recommend moving content to referenced files.
+
+### Step 3: Assess .claude/settings.json
+
+**If it does not exist:**
+
+```
+GAP: .claude/settings.json does not exist
+IMPACT: No permission scoping, no hooks — agent can run any command and writes are not validated
+FIX: Create .claude/settings.json with permissions and recommended hooks
+ACTION: Let Claude handle this? (y/n)
+```
+
+If the user says yes, generate a settings file based on the project's tech stack (detected from CLAUDE.md, package.json, pyproject.toml, Cargo.toml, go.mod, or similar). Use `knowledge/sample-files-kit.md` as a reference for structure.
+
+**If it exists:** Check for:
+- `permissions.allow` — are common safe commands listed?
+- `permissions.deny` — are destructive commands blocked?
+- `hooks.PreToolUse` — any pre-write guards?
+- `hooks.PostToolUse` — any post-write validators (lint, type check, secret scan)?
+
+Report what is present and what is missing.
+
+### Step 4: Assess .gitignore
+
+Check if `.gitignore` exists and whether it contains these kit-specific entries:
+
+```
+.claude/temp/
+.harness-kit.lock
+code-review-results/
+```
+
+**If .gitignore does not exist:**
+
+```
+GAP: .gitignore does not exist
+IMPACT: Temp files, lock files, and review results may be committed to the repo
+FIX: Create .gitignore with kit entries (and standard entries for detected stack)
+ACTION: Let Claude handle this? (y/n)
+```
+
+**If .gitignore exists but missing kit entries:**
+
+```
+GAP: .gitignore missing harness-kit entries
+IMPACT: Temp files and review results may be committed to the repo
+FIX: Append kit entries to .gitignore (idempotent, with marker comment)
+ACTION: Let Claude handle this? (y/n)
+```
+
+If the user says yes, append idempotently using a marker:
+
+```
+# --- harness-kit ---
+.claude/temp/
+.harness-kit.lock
+code-review-results/
+# --- /harness-kit ---
+```
+
+Before appending, check if the marker already exists. If it does, skip.
+
+### Step 5: Assess Standards and Review Infrastructure
+
+**Check for `standards/code-review.md`:**
+
+If it does not exist:
+
+```
+GAP: standards/code-review.md does not exist
+IMPACT: Code reviews have no standard to evaluate against — /code-review-pr will lack project-specific criteria
+FIX: Create a skeleton code-review.md for the team to customize
+ACTION: Let Claude handle this? (y/n)
+```
+
+If the user says yes, create a skeleton with sections for: Scope, Severity Levels, Evaluation Criteria (Architecture, Code Quality, Testing, Documentation), and a note to customize.
+
+**Check for `code-review-results/` directory:**
+
+If it does not exist:
+
+```
+GAP: code-review-results/ directory does not exist
+IMPACT: /code-review-pr and /harvest-reviews have no output directory
+FIX: Create code-review-results/ directory
+ACTION: Let Claude handle this? (y/n)
+```
+
+**Check for `.claude/temp/` directory:**
+
+If it does not exist:
+
+```
+GAP: .claude/temp/ directory does not exist
+IMPACT: Agents have no scratch space for temporary files (issue context, plans, etc.)
+FIX: Create .claude/temp/ directory
+ACTION: Let Claude handle this? (y/n)
+```
+
+### Step 6: Assess Tooling and Environment
+
+**GitHub CLI:**
+
+Run `gh auth status` to check if the GitHub CLI is authenticated.
+
+If not authenticated:
+
+```
+GAP: GitHub CLI not authenticated
+IMPACT: Issue fetching, PR creation, and label management will not work
+FIX: Run `gh auth login` (user must do this manually)
+ACTION: Manual — run `gh auth login` to authenticate
+```
+
+**Git repo:**
+
+If `.git/` does not exist:
+
+```
+GAP: Git repository not initialized
+IMPACT: Branch management, commits, and PR workflows will not work
+FIX: Run `git init` and set up remote
+ACTION: Let Claude handle `git init`? (y/n) (Remote setup is manual)
+```
+
+### Step 7: Assess Existing Commands and Agents
+
+List any files in `.claude/commands/` and `.claude/agents/`.
+
+If they exist, report them — they may be custom commands the team already uses. Do not suggest removing them.
+
+If they do not exist, note that harness-kit commands (like `/story-runner`, `/code-review-pr`, `/harvest-reviews`) are available from the kit and can be referenced or copied.
+
+```
+EXISTING COMMANDS: None found
+NOTE: harness-kit provides commands for story running, code review, and review harvesting.
+      These work via the kit — no need to copy them into your project.
+```
+
+### Step 8: Summary and Action Plan
+
+Present a final summary table:
+
+```
+INTEGRATION SUMMARY
+
+| Component | Status | Action |
+| --- | --- | --- |
+| Git repo | Ready | — |
+| CLAUDE.md | Missing | Create from template |
+| .claude/settings.json | Missing | Create with hooks |
+| .gitignore | Partial | Append kit entries |
+| standards/code-review.md | Missing | Create skeleton |
+| code-review-results/ | Missing | Create directory |
+| .claude/temp/ | Missing | Create directory |
+| GitHub CLI | Authenticated | — |
+| Existing commands | None | Kit commands available |
+
+Ready to proceed with approved actions.
+```
+
+Then execute only the actions the user approved. After each action, confirm what was done.
+
+### Step 9: Post-Integration Verification
+
+After all approved actions are complete, do a quick re-check:
+
+```
+POST-INTEGRATION CHECK
+
+- [x] CLAUDE.md exists and has N/6 canonical sections
+- [x] .claude/settings.json exists with permissions and hooks
+- [x] .gitignore has kit entries
+- [x] standards/code-review.md exists
+- [x] code-review-results/ directory exists
+- [x] .claude/temp/ directory exists
+- [x] Git repo initialized
+- [x] GitHub CLI authenticated
+
+Harness integration complete.
+```
+
+If any items were deferred by the user, list them as follow-up tasks:
+
+```
+DEFERRED (handle manually):
+1. Add Architecture section to CLAUDE.md
+2. Configure GitHub CLI authentication
+```
+
+---
+
+## ERROR HANDLING
+
+- **Cannot determine tech stack:** Ask the user directly rather than guessing
+- **File write permission denied:** Report the error and suggest the user fix permissions
+- **Existing file conflicts:** Never overwrite — show a diff of proposed changes and ask for approval
+- **Partial completion:** Report what was done and what remains, so the user can re-run or finish manually
+
+---
+
+## NOTES
+
+- This command is safe to run multiple times — it is idempotent and will skip components that are already in place
+- The six canonical CLAUDE.md sections are defined in `knowledge/claude-md-kit.md`
+- Sample files for reference are in `knowledge/sample-files-kit.md`
+- The `--dry-run` flag is recommended for first use to preview the assessment without changes
+- This command works on any tech stack — it detects the stack from existing config files and asks the user when uncertain

--- a/.claude/commands/plan-issue-kit.md
+++ b/.claude/commands/plan-issue-kit.md
@@ -1,0 +1,160 @@
+# Plan Issue (Phase 2: Planning)
+
+**Purpose:** Deep planning - analyze issue, load full context, create comprehensive implementation plan.
+
+**Usage:** `/plan-issue <issue-number>`
+
+**Prerequisites:** Must run `/prep-issue <issue-number>` first
+
+**Next Steps:** After reviewing plan, run `/implement-issue <issue-number>`
+
+---
+
+## WHAT THIS COMMAND DOES
+
+1. Read issue from `.claude/temp/GH-ISSUE-<number>-REMOVE.md`
+2. Read context hint from `.claude/temp/CONTEXT-HINT-<number>-REMOVE.md`
+3. Load project context (CLAUDE.md, README.md)
+4. Explore codebase to understand current state
+5. Analyze issue deeply - requirements, constraints, risks
+6. Create detailed implementation plan
+7. Output plan to `.claude/temp/PLAN-<number>-REMOVE.md`
+
+**This command does NOT:**
+
+- Execute the plan (that's `/implement-issue`)
+- Write any code
+- Make any changes to codebase (read-only analysis)
+
+---
+
+## EXECUTION STEPS
+
+### Step 1: Validate Prerequisites
+
+Check `.claude/temp/GH-ISSUE-<number>-REMOVE.md` and `.claude/temp/CONTEXT-HINT-<number>-REMOVE.md` exist.
+
+### Step 2: Load Issue and Context Hint
+
+Read both files, extract key information.
+
+### Step 3: Load Project Context
+
+**Always load:**
+
+1. `CLAUDE.md` - Essential project guide
+2. `README.md` - Project overview
+
+### Step 4: Explore Codebase
+
+Use Explore subagent or direct file reads to understand:
+
+- Current project structure
+- Existing components and patterns
+- How new work fits with existing code
+
+### Step 5: Deep Analysis
+
+- What is the actual requirement?
+- What are the acceptance criteria?
+- What files need to be created/modified?
+- What could go wrong?
+- Are there integration points?
+
+**Escalation protocol:**
+
+- If issue is too complex or ambiguous: Stop and ask human
+- If multiple valid approaches: Present options to human
+- After 3 failed attempts: Request human guidance
+
+### Step 6: Create Implementation Plan
+
+**Write:** `.claude/temp/PLAN-<number>-REMOVE.md`
+
+```markdown
+# Implementation Plan for Issue #<number>
+
+**TEMPORARY SESSION DOCUMENT - REMOVE AFTER SESSION**
+
+---
+
+## Issue Summary
+
+**Title:** <title>
+**Description:** <brief summary>
+**Complexity:** Low/Medium/High
+**Estimated Time:** <X hours>
+
+---
+
+## Analysis
+
+**What needs to be done:**
+<Clear explanation>
+
+**Risks and concerns:**
+
+- <Risk 1>
+- <Risk 2>
+
+---
+
+## Files to Modify
+
+**Create:**
+
+- `path/to/new-file` — Purpose: <description>
+
+**Modify:**
+
+- `path/to/existing-file` — Changes: <what to change>
+
+---
+
+## Implementation Steps
+
+### Phase 1: <Phase Name>
+
+**Task 1.1: <Task Name>**
+
+- **What:** <Clear description>
+- **How:** <Step-by-step>
+- **Files:** <Which files>
+- **Success criteria:** <How to verify>
+
+### Phase 2: Testing & Verification
+
+**Task 2.1: Run quality checks**
+
+- Run lint, build commands from `CLAUDE.md`
+
+**Task 2.2: Test implementation**
+
+- Specific test commands and scenarios
+
+**Task 2.3: Create verification document**
+
+- `.claude/temp/VERIFICATION-<number>-REMOVE.md`
+
+---
+
+## Verification Checklist
+
+- [ ] All tasks completed
+- [ ] Lint passing (per CLAUDE.md)
+- [ ] Build passes (per CLAUDE.md)
+- [ ] Quality checks pass
+- [ ] Implementation tested
+```
+
+### Step 7: Output Summary
+
+Display plan summary with complexity, estimated time, files to modify, and next steps.
+
+---
+
+## NOTES
+
+- Planning may take 2-5 minutes
+- Plan should be detailed enough for mechanical execution
+- If unsure about anything, abort and ask - don't guess

--- a/.claude/commands/prep-issue-kit.md
+++ b/.claude/commands/prep-issue-kit.md
@@ -1,0 +1,116 @@
+# Prep Issue (Phase 1: Setup)
+
+**Purpose:** Fast setup for issue implementation - create branch, fetch issue, generate context hints.
+
+**Usage:** `/prep-issue <issue-number>`
+
+**Next Steps:** After this completes, run `/plan-issue <issue-number>`
+
+---
+
+## WHAT THIS COMMAND DOES
+
+1. Validate issue exists on GitHub
+2. Create feature branch with proper naming
+3. Fetch issue from GitHub and save locally
+4. Create lightweight context hint file
+5. Set up temp workspace for planning phase
+
+**This command does NOT:**
+
+- Create implementation plan (that's `/plan-issue`)
+- Write any code (that's `/implement-issue`)
+
+---
+
+## EXECUTION STEPS
+
+### Step 1: Validate Issue Number
+
+```bash
+gh issue view <issue-number> --json number,title,body,labels,state,comments
+```
+
+**If issue not found:** Exit with error.
+**If issue found:** Parse JSON and continue.
+
+### Step 2: Check Git Status
+
+```bash
+git status --porcelain
+```
+
+If uncommitted changes exist, warn user and suggest options (commit, stash, or discard).
+
+### Step 3: Update Main Branch
+
+```bash
+git fetch origin && git checkout main && git pull origin main
+```
+
+### Step 4: Create Feature Branch
+
+**Branch naming format:** Use convention from `CLAUDE.md`. Default:
+
+```
+feature/issue-<number>-<description>
+```
+
+- Convert title to lowercase, replace spaces with hyphens, remove special chars, truncate to ~30 chars
+
+```bash
+git checkout -b feature/issue-<number>-<description>
+```
+
+### Step 5: Save Issue to File
+
+**Create:** `.claude/temp/GH-ISSUE-<number>-REMOVE.md`
+
+Include: issue metadata, full description, all comments with author and timestamp.
+
+### Step 6: Create Context Hint File
+
+**Create:** `.claude/temp/CONTEXT-HINT-<number>-REMOVE.md`
+
+Extract from issue text (no codebase exploration needed):
+
+- Key terms from title and body
+- Files/paths mentioned
+- Related issue numbers
+- Suggested directories for exploration
+- Relevant areas of the codebase
+
+**Token target:** ~100-200 tokens
+
+### Step 7: Output Summary
+
+```
+Prep Issue #<number> Complete
+
+Branch created: feature/issue-<number>-<description>
+
+Files created:
+- .claude/temp/GH-ISSUE-<number>-REMOVE.md
+- .claude/temp/CONTEXT-HINT-<number>-REMOVE.md
+
+Next steps:
+1. Run /plan-issue <number> to create implementation plan
+2. Review plan
+3. Run /implement-issue <number> to execute plan
+```
+
+---
+
+## ERROR HANDLING
+
+- **Issue not found:** Error with guidance to check issue number and gh auth
+- **Branch already exists:** Offer to use existing or delete and recreate
+- **Git not clean:** Warn with options (commit, stash, discard)
+
+---
+
+## NOTES
+
+- This command is FAST (~30-45 seconds)
+- Does not load heavy context
+- Always run `/plan-issue` next (don't skip to /implement-issue)

--- a/.claude/commands/start-worktree-kit.md
+++ b/.claude/commands/start-worktree-kit.md
@@ -1,0 +1,90 @@
+# Start Worktree for Issue
+
+**Purpose:** Create a git worktree for working on a specific GitHub issue in parallel with other work.
+
+**Usage:** `/start-worktree <issue-number>`
+
+---
+
+## Steps
+
+### 1. Validate Issue Exists
+
+```bash
+gh issue view $ARGUMENTS --json number,title,body
+```
+
+If issue doesn't exist, display error and stop.
+
+### 2. Check for Existing Worktree
+
+```bash
+git worktree list
+```
+
+If a worktree for this issue already exists, warn user and offer to use existing or recreate.
+
+### 3. Derive Worktree Path
+
+Use the worktree path convention from `CLAUDE.md`. Default:
+
+```bash
+PROJECT_NAME=$(basename $(git rev-parse --show-toplevel))
+WORKTREE_PATH="../${PROJECT_NAME}-issue-$ARGUMENTS"
+```
+
+### 4. Create Worktree
+
+```bash
+git worktree add "$WORKTREE_PATH" -b feature/issue-$ARGUMENTS
+```
+
+### 5. Display Success Message
+
+```
+Worktree created for issue #<number>
+
+Location: <worktree-path>
+Branch: feature/issue-<number>
+
+Next steps:
+1. Open in new VS Code window:
+   code <worktree-path>
+
+2. In the new window, install dependencies:
+   <install command from CLAUDE.md>
+
+3. Start the workflow:
+   /story-runner <number>
+
+   Or run phases manually:
+   /prep-issue <number>
+   /plan-issue <number>
+   /implement-issue <number>
+
+---
+Worktree Management:
+
+List all worktrees:     git worktree list
+Remove when done:       git worktree remove <worktree-path>
+Remove branch:          git branch -d feature/issue-<number>
+```
+
+---
+
+## Important Notes
+
+- **Keep prep-issue unchanged** — Don't fetch or save issue details here; let `/prep-issue` handle that
+- **Port conflicts** — If running multiple dev servers, use different ports
+- **Separate git state** — Each worktree has independent working tree and staging area
+- **Shared repository** — All worktrees share the same `.git` directory
+
+## Cleanup
+
+When issue is complete and PR is merged:
+
+```bash
+git worktree remove <worktree-path>
+git branch -d feature/issue-<number>
+git push origin --delete feature/issue-<number>
+```

--- a/.claude/commands/story-runner-kit.md
+++ b/.claude/commands/story-runner-kit.md
@@ -1,0 +1,144 @@
+# Story Runner
+
+**Purpose:** Run complete issue workflow via agents with minimal context usage.
+
+**Usage:** `/story-runner <issue-number>`
+
+---
+
+## Overview
+
+This command orchestrates three agents to complete a GitHub issue:
+
+1. **prep-agent** - Fetch issue, create branch, generate context hints
+2. **plan-agent** - Deep analysis, create implementation plan
+3. **implement-agent** - Execute plan, test, commit, create PR
+
+Each agent runs in an isolated context, preserving your main context window.
+
+---
+
+## Execution
+
+### Step 1: Validate Input
+
+Extract issue number from command argument: `$ARGUMENTS`
+
+**If no issue number provided:**
+
+```
+Usage: /story-runner <issue-number>
+
+Example: /story-runner 42
+```
+
+### Step 2: Spawn prep-agent
+
+**Launch agent using Agent tool:**
+
+```
+Agent tool invocation:
+- subagent_type: general-purpose
+- model: haiku
+- prompt: |
+    You are prep-agent. Your task is to prepare for implementing GitHub issue #<number>.
+
+    Follow the instructions in the prep-agent definition exactly.
+
+    Return either:
+    - SUCCESS: with summary of what was created
+    - ABORT: with specific blocker and suggested actions
+```
+
+**Wait for agent response.**
+
+**On SUCCESS:** Continue to Step 3
+**On ABORT:** Display blocker and stop.
+
+### Step 3: Spawn plan-agent
+
+**Launch agent using Agent tool:**
+
+```
+Agent tool invocation:
+- subagent_type: general-purpose
+- model: opus
+- prompt: |
+    You are plan-agent. Your task is to create an implementation plan for GitHub issue #<number>.
+
+    Prerequisites exist:
+    - .claude/temp/GH-ISSUE-<number>-REMOVE.md
+    - .claude/temp/CONTEXT-HINT-<number>-REMOVE.md
+
+    Follow the instructions in the plan-agent definition exactly.
+
+    Return either:
+    - SUCCESS: with summary of plan created
+    - ABORT: with specific blocker and suggested actions
+```
+
+**Wait for agent response.**
+
+**On SUCCESS:** Continue to Step 4
+**On ABORT:** Display blocker and stop.
+
+### Step 4: Spawn implement-agent
+
+**Launch agent using Agent tool:**
+
+```
+Agent tool invocation:
+- subagent_type: general-purpose
+- prompt: |
+    You are implement-agent. Your task is to implement GitHub issue #<number>.
+
+    Prerequisites exist:
+    - .claude/temp/GH-ISSUE-<number>-REMOVE.md
+    - .claude/temp/PLAN-<number>-REMOVE.md
+
+    Follow the instructions in the implement-agent definition exactly.
+
+    Return either:
+    - SUCCESS: with PR URL and summary
+    - ABORT: with specific blocker and suggested actions
+```
+
+**Wait for agent response.**
+
+**On SUCCESS:** Display completion message (Step 5)
+**On ABORT:** Display blocker and stop.
+
+### Step 5: Success - Display Completion
+
+```
+STORY RUNNER COMPLETE
+
+Issue: #<number>
+Pull Request: <PR URL from implement-agent>
+
+All phases completed:
+- prep-agent: Branch created, issue fetched
+- plan-agent: Implementation plan created
+- implement-agent: Code implemented, tested, PR created
+
+Next steps:
+1. Review PR at <PR URL>
+2. Perform any additional manual testing
+3. Approve and merge if satisfied
+4. Clean up: rm .claude/temp/*-<number>-REMOVE.md
+```
+
+---
+
+## Error Handling
+
+If an agent doesn't respond or returns unexpected results, display the phase, issue number, and suggested recovery actions (resume manually with individual phase commands).
+
+---
+
+## Related Commands
+
+- `/prep-issue <n>` - Just prep phase
+- `/plan-issue <n>` - Just planning phase
+- `/implement-issue <n>` - Just implementation phase
+- `/code-review-pr <n>` - Review PR against standards

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,62 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Glob",
+      "Grep",
+      "Edit",
+      "Write",
+      "Bash(npm test*)",
+      "Bash(npm run lint*)",
+      "Bash(npm run format*)",
+      "Bash(npm run build*)",
+      "Bash(npm run dev*)",
+      "Bash(npm run db:*)",
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git add*)",
+      "Bash(git commit*)",
+      "Bash(git branch*)",
+      "Bash(git checkout*)",
+      "Bash(git switch*)",
+      "Bash(gh issue*)",
+      "Bash(gh pr*)",
+      "Bash(ls *)",
+      "Bash(curl http://localhost*)"
+    ],
+    "deny": [
+      "Bash(rm -rf*)",
+      "Bash(npm publish*)",
+      "Bash(docker*)",
+      "Bash(ssh*)",
+      "Read(**/.env*)",
+      "Read(~/.ssh/*)",
+      "Read(~/.aws/*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'BLOCKED=\".env .env.local package-lock.json\"; for f in $BLOCKED; do if [[ \"$CLAUDE_FILE_PATH\" == *\"$f\" ]]; then echo \"BLOCKED: $f is protected.\" >&2; exit 1; fi; done'"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'if grep -nEi \"(api_key|secret|password|token)\\s*[:=]\\s*[\\x27\\\"][A-Za-z0-9]{8,}\" \"$CLAUDE_FILE_PATH\" 2>/dev/null; then echo \"Possible hardcoded secret.\" >&2; exit 1; fi'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ coverage/
 # Temporary files
 *.tmp
 .temp/
+
+# --- harness-kit ---
+.harness-kit.lock
+code-review-results/
+# --- /harness-kit ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,420 +1,58 @@
-# Claude Developer Guide
-
-**Essential information for Claude AI sessions working on this project**
-
----
-
-## Quick Start for New Sessions
-
-### 1. Project Overview
-- **Name:** Checked Out - Library Management System
-- **Architecture:** 3-tier (React frontend + Express backend + MySQL database)
-- **Purpose:** Teaching full-stack development with modern technologies
-
-### 2. Key Standards
-All standards are in `/standards/quick-ref/`:
-- [frontend-quick-ref.md](standards/quick-ref/frontend-quick-ref.md) - React + Material UI patterns
-- [backend-quick-ref.md](standards/quick-ref/backend-quick-ref.md) - Node.js + Express + Sequelize patterns
-- [craftsmanship-quick-ref.md](standards/quick-ref/craftsmanship-quick-ref.md) - DRY, KISS, SOLID principles
-
-### 3. Workflow
-
-**Agent-based workflow (recommended for context efficiency):**
-```bash
-/story-runner <number>   # Runs all 3 phases via agents, minimal context usage
-```
-
-**Manual workflow (for control or debugging):**
-```bash
-/prep-issue <number>     # Phase 1: Setup and context (Sonnet)
-/plan-issue <number>     # Phase 2: Deep planning (Opus)
-/implement-issue <number> # Phase 3: Execution (Sonnet)
-```
-
-See [.claude/commands/](.claude/commands/) for complete command documentation.
-
----
-
-## Agent-Based Workflow
-
-For maximum context efficiency, use the agent-based workflow:
-
-```bash
-/story-runner <issue-number>
-```
-
-This spawns three agents in sequence, each in an isolated context:
-
-1. **prep-agent** - Fetch issue, create branch, generate context hints
-2. **plan-agent** - Deep analysis, create implementation plan (with enterprise patterns)
-3. **implement-agent** - Execute plan, test, commit, create PR
-
-**Benefits:**
-- Each agent runs in isolated 200k context
-- Main context preserved for other work (~2-5k tokens used for orchestration)
-- Can run multiple issues in parallel via worktrees
-- Same quality as manual workflow, but automated
-
-**When to use manual workflow instead:**
-- Agent aborted and you want to resume from a specific phase
-- Complex/ambiguous issue where you expect mid-flight decisions
-- Debugging agent behavior
-- Teaching someone the workflow
-
-**Agent definitions:** `.claude/agents/`
-**Enterprise patterns:** `standards/quick-ref/enterprise-patterns-quick-ref.md`
-
----
-
-## Database Access
-
-**IMPORTANT:** Claude can query the MySQL database using Sequelize via Node.js one-liners.
-
-### How to Query Database
-
-**Recommended method (uses project .env config):**
-```bash
-cd backend && node -e "
-const db = require('./src/models');
-db.sequelize.query('SELECT COUNT(*) as count FROM books')
-  .then(([results]) => {
-    console.log(JSON.stringify(results, null, 2));
-  })
-  .catch(err => console.error('Error:', err.message))
-  .finally(() => process.exit(0));
-"
-```
-
-**Why this works:**
-- Uses existing `.env` configuration (no password in commands)
-- Full access to Sequelize ORM
-- Can execute any SQL query
-- Returns JSON results
-
-### Common Database Queries
-
-**Check if database exists:**
-```bash
-cd backend && node -e "
-const db = require('./src/models');
-db.sequelize.authenticate()
-  .then(() => console.log('✅ Database connected'))
-  .catch(err => console.error('❌ Error:', err.message))
-  .finally(() => process.exit(0));
-"
-```
-
-**Get table counts:**
-```bash
-cd backend && node -e "
-const db = require('./src/models');
-db.sequelize.query('SHOW TABLES')
-  .then(([tables]) => {
-    console.log('Tables:', tables);
-    return Promise.all(
-      tables.map(t => {
-        const tableName = t['Tables_in_checked_out'];
-        return db.sequelize.query(\`SELECT COUNT(*) as count FROM \${tableName}\`)
-          .then(([result]) => ({ table: tableName, count: result[0].count }));
-      })
-    );
-  })
-  .then(counts => console.log(JSON.stringify(counts, null, 2)))
-  .finally(() => process.exit(0));
-"
-```
-
-**Query specific data:**
-```bash
-cd backend && node -e "
-const db = require('./src/models');
-db.sequelize.query('SELECT * FROM books LIMIT 5')
-  .then(([results]) => console.log(JSON.stringify(results, null, 2)))
-  .finally(() => process.exit(0));
-"
-```
-
-### Database Prerequisites
-
-If you get `Error: Unknown database 'checked_out'`:
-1. Database hasn't been created yet
-2. Document this as a blocker in verification
-3. Provide setup instructions for human
-
-**Setup commands (for human):**
-```bash
-# Create database
-mysql -u root -p <<EOF
-CREATE DATABASE checked_out CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-EOF
-
-# Run migrations
-cd backend && npm run db:migrate
-
-# Seed database (optional)
-npm run db:seed
-```
-
----
-
-## Testing Implementation
-
-**CRITICAL:** When implementing features, you MUST test them before creating verification document.
-
-### Backend Testing
-
-**Run seeders:**
-```bash
-cd backend && npm run db:seed
-```
-
-**Test API endpoints:**
-```bash
-# Start server in background
-cd backend && npm run dev &
-SERVER_PID=$!
-
-# Wait for server to start
-sleep 3
-
-# Test endpoint
-curl http://localhost:3000/api/health
-
-# Stop server
-kill $SERVER_PID
-```
-
-**Query database to verify:**
-```bash
-cd backend && node -e "
-const db = require('./src/models');
-db.sequelize.query('SELECT COUNT(*) FROM books')
-  .then(([results]) => console.log('Books:', results[0].count))
-  .finally(() => process.exit(0));
-"
-```
-
-### Frontend Testing
-
-**Start dev server:**
-```bash
-cd frontend && timeout 5 npm run dev || true
-# Note: Use short timeout to verify it starts, don't leave running
-```
-
-**Check for errors:**
-```bash
-cd frontend && npm run build 2>&1 | head -20
-```
-
-### Code Quality
-
-**Always run before creating verification:**
-```bash
-# Backend
-cd backend && npm run lint && npm run format
-
-# Frontend
-cd frontend && npm run lint && npm run format
-```
-
----
-
-## Verification Document Format
-
-After implementation, create `.claude/temp/VERIFICATION-<issue#>-REMOVE.md` with:
-
-### Required Sections
-
-1. **Implementation Summary**
-   - List all files created/modified
-   - Briefly describe changes
-
-2. **Claude's Test Results** ← CRITICAL
-   - Show actual commands you ran
-   - Include real output (copy/paste)
-   - Show database queries and results
-   - Document any blockers encountered
-   - Explain what you tested vs. what was blocked
-
-3. **Additional Testing for Human**
-   - Tests you couldn't perform (with reasons why)
-   - Step-by-step instructions
-   - Expected results
-
-4. **Quality Checks Completed**
-   - ESLint/Prettier status
-   - No console.log statements
-   - Standards compliance verified
-   - **Checkbox for "Claude tested implementation"**
-
-See [.claude/commands/EXAMPLE-VERIFICATION-FORMAT.md](.claude/commands/EXAMPLE-VERIFICATION-FORMAT.md) for complete example.
-
----
-
-## Common Patterns
-
-### Sequelize Model Pattern
-```javascript
-const { DataTypes } = require('sequelize');
-
-module.exports = (sequelize) => {
-  const Model = sequelize.define('ModelName', {
-    id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
-    field: { type: DataTypes.STRING(255), allowNull: false },
-  }, {
-    tableName: 'table_name',
-    timestamps: true,
-    underscored: true,
-  });
-
-  Model.associate = (models) => {
-    // Associations here
-  };
-
-  return Model;
-};
-```
-
-### Service Pattern
-```javascript
-class BookService {
-  async getAllBooks(filters = {}) {
-    const where = {};
-    if (filters.genre) where.genre = filters.genre;
-    return Book.findAll({ where });
-  }
-}
-```
-
-### Controller Pattern
-```javascript
-class BookController {
-  async getAllBooks(req, res, next) {
-    try {
-      const result = await bookService.getAllBooks(req.query);
-      res.json(ApiResponse.success(result));
-    } catch (error) {
-      next(error);
-    }
-  }
-}
-```
-
----
-
-## Escalation Protocol
-
-### When to Ask Human for Help
-
-**Immediate escalation (don't waste time):**
-- Issue requirements are unclear or ambiguous
-- Multiple valid approaches with unclear trade-offs
-- Architectural decisions needed
-- Cannot access required resources (database, APIs)
-
-**Three-strikes rule:**
-- After 3 failed attempts to fix a bug: Escalate with details
-- After 3 failed test runs: Explain what you tried, ask for help
-
-**Blocking dependencies:**
-- Database doesn't exist → Document in verification, provide setup steps
-- API keys missing → Document requirement, ask human to provide
-- External service down → Note in verification, suggest workarounds
-
----
-
-## File Locations
-
-**Important files:**
-- Project standards: `/standards/quick-ref/`
-- Backend code: `/backend/src/`
-- Frontend code: `/frontend/src/`
-- Database scripts: `/database/scripts/`
-- Slash commands: `/.claude/commands/`
-
-**Configuration:**
-- Backend env: `/backend/.env` (database credentials)
-- Frontend env: `/frontend/.env` (API URL)
-- Database config: `/backend/src/config/database.js`
-
-**Testing outputs:**
-- Session files: `/.claude/temp/` (temporary, remove after session)
-- Verification docs: `/.claude/temp/VERIFICATION-<number>-REMOVE.md`
-
----
-
-## Quality Standards
-
-### Must-haves before marking complete:
-- [ ] ESLint passing (no new warnings/errors)
-- [ ] Prettier formatted
-- [ ] No console.log statements in production code
-- [ ] PropTypes defined (React components)
-- [ ] Tests written (if applicable)
-- [ ] **Implementation actually tested by Claude**
-- [ ] Verification document with real results
-- [ ] Human validated functionality
-
-### Code reviews check for:
-- DRY: No repeated code
-- KISS: Simple, clear solutions
-- SOLID: Single responsibility, proper abstractions
-- Error handling: All edge cases covered
-- Security: No exposed credentials, SQL injection protected
-
----
-
-## Quick Reference
-
-**Start server:**
-```bash
-# Both services
-./scripts/start-all.sh
-
-# Backend only
-./scripts/start-backend.sh
-
-# Frontend only
-./scripts/start-frontend.sh
-```
-
-**Stop services:**
-```bash
-./scripts/stop-all.sh
-```
-
-**Database operations:**
-```bash
-cd backend
-npm run db:migrate      # Run migrations
-npm run db:seed         # Seed data
-npm run db:seed:undo    # Undo last seed
-```
-
-**Code quality:**
-```bash
-npm run lint    # Check code style
-npm run format  # Auto-format code
-npm test        # Run tests
-```
-
----
-
-## Session Notes
-
-**For your current session:**
-- Review existing verification docs in `.claude/temp/` to understand recent work
-- Check git status to see uncommitted changes
-- Read issue in `.claude/temp/GH-ISSUE-<number>-REMOVE.md` if continuing work
-- Use TodoWrite to track progress through complex tasks
-
-**Before ending session:**
-- Complete verification document with your test results
-- Mark final todo as "waiting for human validation"
-- Don't commit or create PR (human does that after validating)
-
----
-
-**Last updated:** 2025-11-03
-**For questions:** See project README.md or standards documentation
+# CLAUDE.md
+
+## Tech Stack
+
+Checked Out is a library management system for teaching full-stack development.
+React 18 + Vite + Material UI frontend, Express + Sequelize backend, MySQL database.
+3-tier architecture. Uses React Query for server state, Joi for validation.
+
+## Architecture
+
+- Three layers: routes -> controllers -> services -> models. Dependencies flow downward only.
+- Controllers handle HTTP parsing and responses. Services contain all business logic.
+- Models define Sequelize schemas and associations. No raw SQL outside models.
+- Frontend: pages -> components -> hooks -> services (API calls).
+- Shared utilities in `backend/src/utils/` and `frontend/src/utils/`.
+
+## Commands
+
+- Install: `cd backend && npm install` / `cd frontend && npm install`
+- Dev server (both): `./scripts/start-all.sh`
+- Backend only: `cd backend && npm run dev` (port 3000)
+- Frontend only: `cd frontend && npm run dev` (port 5173)
+- Lint: `cd backend && npm run lint` / `cd frontend && npm run lint`
+- Format: `cd backend && npm run format` / `cd frontend && npm run format`
+- Migrate: `cd backend && npm run db:migrate`
+- Seed: `cd backend && npm run db:seed`
+- Stop services: `./scripts/stop-all.sh`
+
+## Constraints
+
+- Do NOT put business logic in controllers. Controllers call services. Period.
+- Do NOT use console.log in production code. Use the structured logger.
+- Do NOT use raw SQL queries. Use Sequelize ORM methods.
+- Do NOT commit .env files or hardcode credentials.
+- Do NOT skip testing. Run lint + format before marking work complete.
+- Do NOT import frontend services directly in components — use hooks.
+
+## Conventions
+
+- Backend: camelCase variables/functions, PascalCase classes, UPPER_SNAKE_CASE constants.
+- Frontend: PascalCase components/files, camelCase props, handle* event handlers, use* hooks.
+- All React components must define PropTypes.
+- Use Material UI theme tokens — no inline color or spacing values.
+- API responses use `ApiResponse.success()` / `ApiResponse.error()` wrappers.
+- Sequelize models use `underscored: true` and `timestamps: true`.
+- Error handling: try/catch in controllers, throw typed errors from services.
+
+## Context Guidance
+
+- Backend code: `backend/src/` — see [backend-quick-ref.md](standards/quick-ref/backend-quick-ref.md)
+- Frontend code: `frontend/src/` — see [frontend-quick-ref.md](standards/quick-ref/frontend-quick-ref.md)
+- Craftsmanship: [craftsmanship-quick-ref.md](standards/quick-ref/craftsmanship-quick-ref.md)
+- Database guide: [database-guide.md](standards/quick-ref/database-guide.md)
+- Testing guide: [testing-guide.md](standards/quick-ref/testing-guide.md)
+- Code review standard: [code-review.md](standards/code-review.md)
+- Config: `backend/.env` (DB creds), `frontend/.env` (API URL), `backend/src/config/database.js`
+- Slash commands: `.claude/commands/` — use `/story-runner <number>` for agent-based workflow
+- Verification docs: `.claude/temp/VERIFICATION-<number>-REMOVE.md`

--- a/knowledge/agent-operations-kit.md
+++ b/knowledge/agent-operations-kit.md
@@ -1,0 +1,19 @@
+# Agent Operations
+
+## Error Protocol
+
+All agents use a **three-strikes** protocol for blocked tasks:
+
+1. **First failure:** Debug and retry
+2. **Second failure:** Try alternative approach (consult standards docs if applicable)
+3. **Third failure:** ABORT with detailed explanation of all attempts
+
+## Agent Model Assignments
+
+Any agent or command that spawns another agent MUST specify the model in the invocation.
+
+| Agent      | Model          | Reason                             |
+| ---------- | -------------- | ---------------------------------- |
+| prep-agent | haiku (always) | Fast, lightweight task             |
+| plan-agent | opus (always)  | Deep reasoning required            |
+| All others | caller default | No override — inherits from parent |

--- a/knowledge/architecture-kit.md
+++ b/knowledge/architecture-kit.md
@@ -1,0 +1,233 @@
+# Architecture Enforcement
+
+How to make architecture mechanical rather than aspirational.
+
+## Why Architecture Matters More for Agents
+
+- Humans absorb conventions through code reviews and conversations over months
+- Agents start fresh every session; infer architecture from whatever code is in context
+- Agents cut corners with zero awareness the corners exist
+- **But**: Constraints make agents faster, not slower (narrow solution space = converge faster)
+
+## Classic Four-Layer Model
+
+| Layer              | Responsibility                          |
+| ------------------ | --------------------------------------- |
+| **Presentation**   | Routes, handlers, UI components         |
+| **Application**    | Use cases, orchestration, workflows     |
+| **Domain**         | Business rules, entities, value objects |
+| **Infrastructure** | Database, external APIs, file system    |
+
+**Key Rule:** Dependencies flow downward only.
+
+## Bounded Domains (Vertical Slices)
+
+Within layers, divide by business domain: Users, Billing, Inventory, etc.
+
+- No cross-domain imports except through `shared/interfaces/`
+- Agents can work on one domain without entire codebase in context
+
+## The 300-Line Rule
+
+Files should be describable in one sentence. Over 300 lines = likely needs splitting.
+
+```
+# Before: 780 lines
+src/services/user.service.ts
+
+# After: four focused files
+src/services/auth.service.ts          # 190 lines
+src/services/profile.service.ts       # 140 lines
+src/services/password.service.ts      # 160 lines
+src/services/verification.service.ts  # 120 lines
+```
+
+**Why small files matter for agents:**
+
+- Fit in context without crowding
+- Reduce blast radius of changes
+- Enable better search (grep returns precise results)
+
+## Naming as Navigation
+
+**Bad** — names don't tell you what's inside:
+
+```
+src/helpers.ts, src/utils.ts, src/misc.ts, src/handlers.ts
+```
+
+**Good** — names describe contents:
+
+```
+src/auth.service.ts, src/password-reset.service.ts, src/invoice.routes.ts
+```
+
+Consistent naming convention everywhere. If services use `{thing}.service.ts`, don't break the pattern.
+
+## Module Boundary Enforcement
+
+```typescript
+// Bad: billing reaches into user internals
+import { userDatabase } from "../users/internal/database-connection";
+
+// Good: billing uses user module's public interface
+import { getUserById } from "../users";
+```
+
+Index files as contracts: things in the index are public, everything else is private.
+
+## Architecture Definition File (.harness/architecture.json)
+
+Machine-readable. Read by agents, validated by linters, enforced by CI.
+
+```json
+{
+  "layers": {
+    "presentation": {
+      "path": "src/routes/",
+      "description": "HTTP route handlers — parse request, delegate, format response",
+      "canDependOn": ["application"]
+    },
+    "application": {
+      "path": "src/services/",
+      "description": "Use cases and orchestration",
+      "canDependOn": ["domain", "infrastructure"]
+    },
+    "domain": {
+      "path": "src/domain/",
+      "description": "Business rules, entities, value objects",
+      "canDependOn": []
+    },
+    "infrastructure": {
+      "path": "src/repositories/",
+      "description": "Database access and external APIs",
+      "canDependOn": ["domain"]
+    }
+  },
+  "domains": ["users", "billing", "inventory", "notifications"],
+  "crossDomainRule": "No cross-domain imports except through shared/interfaces/",
+  "bannedPatterns": [
+    {
+      "pattern": "db.query|.execute(",
+      "excludePaths": ["src/repositories/", "src/config/"],
+      "message": "Direct database queries outside repositories"
+    },
+    {
+      "pattern": "process.env",
+      "excludePaths": ["src/config/"],
+      "message": "Environment variable access outside config module"
+    },
+    {
+      "pattern": "console.log",
+      "excludePaths": ["scripts/"],
+      "message": "Use structured logger instead of console.log"
+    }
+  ]
+}
+```
+
+## Custom Linter Script Pattern
+
+Error messages must include fix instructions — they teach the agent how to do it right.
+
+```bash
+#!/bin/bash
+# scripts/check-architecture.sh
+
+ERRORS=0
+
+# No database calls outside repositories
+DB_VIOLATIONS=$(grep -rn "db\.\|\.query(\|\.execute(" src/ \
+  | grep -v "src/repositories/" \
+  | grep -v "src/config/" || true)
+
+if [ -n "$DB_VIOLATIONS" ]; then
+    echo "ERROR: Database queries found outside repository layer:"
+    echo "$DB_VIOLATIONS"
+    echo ""
+    echo "FIX: Move database queries to the appropriate repository file."
+    ERRORS=$((ERRORS + 1))
+fi
+
+# No direct env access outside config
+ENV_VIOLATIONS=$(grep -rn "process\.env" src/ \
+  | grep -v "src/config/" || true)
+
+if [ -n "$ENV_VIOLATIONS" ]; then
+    echo "ERROR: Direct environment variable access outside config:"
+    echo "$ENV_VIOLATIONS"
+    echo ""
+    echo "FIX: Access environment variables through src/config/."
+    ERRORS=$((ERRORS + 1))
+fi
+
+exit $ERRORS
+```
+
+**Helpful error message format:**
+
+```
+ERROR: src/billing/routes/create-invoice.ts imports from
+       src/users/repositories/UserRepository.ts
+
+VIOLATION: Cross-domain import detected. billing/ cannot
+           import directly from users/
+
+FIX: Cross-domain access must go through shared interfaces.
+     1. Check if an interface exists in src/shared/interfaces/
+     2. If not, create one (e.g., UserLookup.ts)
+     3. Import the interface, not concrete implementation
+```
+
+## Brownfield Strategies
+
+For existing codebases, don't rewrite everything. Enforce going forward.
+
+**Start with naming conventions for new files:**
+
+```markdown
+## Naming Rules (for new files)
+
+- Services: {resource}.service.ts
+- Repositories: {resource}.repository.ts
+
+Note: Some existing files don't follow these conventions.
+Follow the conventions above for all NEW files.
+Do not rename existing files unless explicitly asked.
+```
+
+**Use reference implementations:**
+
+```markdown
+## Reference Implementations
+
+Follow patterns in these files for new code:
+
+- Service: src/features/reporting/report.service.ts
+- Repository: src/features/reporting/report.repository.ts
+
+Do NOT use files in src/legacy/ as references.
+```
+
+**Document current vs. target state:**
+
+```markdown
+## Architecture Direction
+
+Migrating from flat service structure to domain-based organization.
+New code: src/features/{feature-name}/
+Legacy code: src/services/ — may import from but do not modify
+```
+
+## Common Mistakes
+
+1. **Over-constraining**: 47 rules before first session. Start with 5-10; add based on observed violations.
+2. **Under-specifying**: "Keep things clean" isn't testable. Every constraint must be machine-testable.
+3. **Forgetting to update**: Architecture file reflects original design but project evolved.
+4. **Too complex**: If a rule needs three paragraphs, simplify to one sentence.
+5. **One-time decision**: Architecture should evolve with the project.
+6. **Not building for deletion**: Design constraints for clean removal when models improve.
+
+## Code Health Threshold
+
+Research shows agents perform optimally on code with health scores 9.5+ (out of 10). Below this, agent performance degrades — struggles with tangled dependencies, unclear naming, inconsistent patterns.

--- a/knowledge/audit-checklist-kit.md
+++ b/knowledge/audit-checklist-kit.md
@@ -1,0 +1,221 @@
+# Audit Checklist and Diagnostics
+
+The complete checklist, diagnostic framework, and failure patterns that harness-cli implements.
+
+## Self-Assessment Checklist (25+ Items)
+
+### Instructions and Knowledge
+
+- [ ] Project-level CLAUDE.md file exists
+- [ ] Lists tech stack with specific versions
+- [ ] Describes architecture (directories, layers, data flow)
+- [ ] Includes concrete code examples of patterns (not just names)
+- [ ] Specifies what the agent should NOT do (constraints)
+- [ ] Folder-level CLAUDE.md files for areas with specific conventions
+- [ ] CLAUDE.md updated when gaps discovered (living document)
+
+### Verification and Back-Pressure
+
+- [ ] Hooks run linter after file writes
+- [ ] Hooks run test suite before commits
+- [ ] Hooks or checks catch forbidden patterns
+- [ ] Agent runs tests as part of workflow (not just when reminded)
+- [ ] Failed checks give agent clear, actionable feedback
+
+### Constraints and Governance
+
+- [ ] Permission settings match risk level of operations
+- [ ] Files/directories that are off-limits are defined
+- [ ] Rules about complexity/scope (when to create new files)
+- [ ] Agent can't make destructive operations without confirmation
+
+### Context Management
+
+- [ ] Sessions scoped to specific tasks (not open-ended)
+- [ ] /compact used proactively before context degrades
+- [ ] New sessions started rather than salvaging confused ones
+- [ ] Sub-agents used for side investigations
+
+### Tools and Capabilities
+
+- [ ] MCP servers set up for needed external tools
+- [ ] Tool access scoped appropriately (read-only where needed)
+- [ ] Agent has tools to verify its own work
+
+### State and Continuity
+
+- [ ] ~/.claude/ memory is curated, not just accumulated
+- [ ] Agent starts each session with enough context to be productive
+- [ ] Critical project decisions documented where agent can access them
+
+### Scoring
+
+- **20+ checked**: Solid harness
+- **12-19**: Decent foundation with significant gaps
+- **6-11**: Major leaks; start with instruction files and architecture
+- **Under 6**: Harness mostly absent; first improvements will have dramatic impact
+
+## Five-Question Diagnostic (Debugging Agent Failures)
+
+### 1. Did it have the right context?
+
+What files were in scope? Did it know about shared utilities? Architecture documentation?
+**Fix:** Add file paths to CLAUDE.md. Use explicit instructions: "Before implementing validation, read src/shared/utils/validation.ts"
+
+### 2. Did it have the right instructions?
+
+Were CLAUDE.md entries clear? Specific? Contradictory? Gaps where agent improvised?
+**Fix:** Update CLAUDE.md with specificity. Instead of "follow established patterns," write "new endpoints must use format in src/shared/utils/response.ts"
+
+### 3. Did it have too much context?
+
+How long was the session? How many files read? Quality degrade over time?
+**Fix:** Use /compact more aggressively. Shorter sessions. Fresh session beats stale session.
+
+### 4. Did back-pressure catch it?
+
+Did agent run tests? Did tests cover the failure? Linter check the pattern?
+**Fix:** Add the missing check: new test, new linter rule, new hook. Make failure impossible to repeat silently.
+
+### 5. Was the task too big?
+
+How many files did it touch? Did it loop without progress?
+**Fix:** Decompose. "Implement entire search" is too big. Break into self-contained pieces.
+
+**Shortcut:** "If I gave this task to a competent developer with the same information, would they make the same mistake?"
+
+- Yes → Fix inputs (spec unclear, context missing, scope unreasonable)
+- No → Need better mechanical constraints
+
+## Seven Common Failure Patterns
+
+### 1. Agent Rewrites Working Code
+
+**Why:** Can't resist "improving" code it passes through.
+**Fixes:**
+
+- CLAUDE.md: "Do not modify code outside current task scope unless explicitly asked"
+- Add tests for touched code (unauthorized changes visible immediately)
+
+### 2. Agent Uses Wrong Patterns
+
+**Why:** Didn't see existing examples, or saw conflicting examples and picked wrong one.
+**Fixes:**
+
+- Concrete examples in CLAUDE.md with specific file references
+- Linter rules checking for anti-patterns
+- Fix existing code demonstrating wrong pattern (agent learns from what it sees)
+
+### 3. Agent Loses Track Mid-Session
+
+**Why:** Context rot. Most predictable failure mode in long sessions.
+**Fixes:**
+
+- /compact proactively
+- 20-minute focused sessions
+- **Doom loop indicator:** 3+ edits to same file without tests improving = kill and restart
+
+### 4. Agent Over-Engineers
+
+**Why:** Defaults to general solutions; doesn't know requirements are narrow.
+**Fixes:**
+
+- CLAUDE.md: "Prefer simplest implementation. No abstraction layers unless explicitly requested."
+- Specific prompts: "Just the function — no class, no configuration, no options object"
+
+### 5. Agent Creates Circular Dependencies
+
+**Why:** Doesn't maintain mental model of dependency graph.
+**Fixes:**
+
+- Document dependency rules: "Routes → Services → Repositories. Nothing depends on Routes."
+- Add circular import detection tool (madge for JS, import-linter for Python)
+
+### 6. Agent Breaks Unrelated Things
+
+**Why:** "Helpfully" fixes what it thinks are related issues.
+**Fixes:**
+
+- Explicit scope boundaries: "Task involves only files in src/users/"
+- Tests for adjacent features
+
+### 7. Agent Ignores Instructions
+
+**Why:** CLAUDE.md too long, instruction lost in noise. Or instruction conflicts with codebase patterns.
+**Fixes:**
+
+- Shorten CLAUDE.md (over 60 lines = more likely to miss individual instructions)
+- Move instruction to mechanical check (linter rule or hook)
+- Make sure codebase demonstrates the rule
+
+## The Iteration Loop
+
+When something goes wrong:
+
+1. **Identify** the specific failure (not "code broken" but "agent put auth in route handler instead of service layer")
+2. **Determine** which harness component should have prevented it
+3. **Update** that component (add rule, write test, fix structure)
+4. **Verify** by starting new session with same task
+
+Step 3 produces a permanent fix for every future session. After 50 iterations, 50 compounded improvements.
+
+**The amateur** fixes code and moves on. **The harness engineer** fixes code and asks "What should have prevented this?"
+
+## Entropy and Anti-Bloat
+
+### The Bloat Problem
+
+Natural tendency to only add, never remove. 6 months in: CLAUDE.md 200 lines, 15 hooks, maze of special cases.
+
+### Pruning Practice (Every Audit)
+
+Remove at least one thing.
+
+1. **Classify each entry:** Model-specific workaround (disposable) or permanent business rule (keeps)?
+2. **Test removals:** Remove, see if agent does right thing without it. If yes, delete.
+3. **Consolidate:** 5 error handling entries → 1 section.
+4. **Prefer mechanical enforcement:** Every CLAUDE.md entry replaceable by linter/hook should be.
+
+### Harness Debt Types
+
+1. **Stale CLAUDE.md** — Rules pointing to non-existent paths
+2. **Broken hooks** — Silently failing or false positives
+3. **Convention drift** — Half the codebase follows pattern A, half pattern B
+4. **Tool rot** — MCP servers for unused services
+5. **Context bloat** — Too many rules; signal lost in noise
+6. **Unmaintained memory** — Stale memories contradicting CLAUDE.md
+
+## Maintenance Cadence
+
+**Monthly (1 hour):**
+
+- Review CLAUDE.md for staleness and contradictions
+- Check hooks are running and catching real issues
+- Review 5-10 recent sessions for patterns
+- Spot-check code for convention drift
+- Remove at least one unused rule/hook
+
+**After Major Changes:**
+
+- Full CLAUDE.md audit
+- Check all hooks still match codebase
+- Audit tool access and permissions
+
+**Quarterly:**
+
+- Deep review of memory; clean stale context
+- Assess overall harness health
+- Plan improvements
+
+## Common Harness Leak Symptoms
+
+| Symptom                                        | Likely Leak                                                              |
+| ---------------------------------------------- | ------------------------------------------------------------------------ |
+| Agent rewrites files not asked to modify       | Missing scope boundaries; no hooks catching out-of-scope modifications   |
+| Agent uses wrong patterns/frameworks           | CLAUDE.md lacks concrete examples; no linting catching mismatches        |
+| Agent loses track mid-session                  | Context overflow; sessions too long/broad                                |
+| Agent makes confident but wrong changes        | No verification; no hooks running tests after implementation             |
+| Must repeat same instructions every session    | Instructions in conversation, not in CLAUDE.md                           |
+| Agent creates unnecessary files/over-engineers | No constraints on scope/complexity                                       |
+| Agent ignores project conventions              | Conventions not documented specifically enough; no enforcement mechanism |
+| Agent ignores instructions                     | CLAUDE.md too long; instructions conflict with codebase patterns         |

--- a/knowledge/claude-md-kit.md
+++ b/knowledge/claude-md-kit.md
@@ -1,0 +1,159 @@
+# CLAUDE.md Best Practices
+
+How to write instruction files that agents actually follow.
+
+## The Six Essential Sections
+
+The canonical section names (used by audit rules to detect completeness):
+
+1. **Tech Stack** — what the project is, language, framework, key tools
+2. **Architecture** — structural rules, layer boundaries, dependency flow
+3. **Commands** — exact commands to build, test, lint, run
+4. **Constraints** — prohibitions and things NOT to do
+5. **Conventions** — naming, style, patterns the linter doesn't catch
+6. **Context Guidance** — pointers to where things are, session guidance
+
+Fixtures and audit rules MUST use these canonical names for section matching. Synonyms (e.g., "Overview" for "Tech Stack", "Do NOT" for "Constraints") should not be used in fixtures — audit rules match on canonical headings.
+
+### 1. Tech Stack
+
+One paragraph: what the project is, what stack, what matters most.
+
+```
+This is a SaaS billing API built with Node.js/Express and PostgreSQL.
+It handles subscription management, invoice generation, and payment
+processing via Stripe. Reliability and data integrity are the top
+priorities — this system handles real money.
+```
+
+### 2. Architecture
+
+Three to five critical structural rules, stated plainly. Pointer to detailed docs if they exist.
+
+```
+- Four-layer architecture: routes → services → domain → repositories.
+  Dependencies flow downward only.
+- Domain layer has ZERO external dependencies.
+- No cross-domain imports. Shared contracts live in src/shared/interfaces/.
+- Database queries belong ONLY in repository files.
+- Full architecture spec: .harness/architecture.json
+```
+
+### 3. Conventions
+
+Five to ten tight rules your linters don't catch. Each must be machine-evaluable.
+
+```
+- Functions: camelCase. Files: kebab-case. Classes: PascalCase.
+- Named exports only. No default exports.
+- Errors: throw typed errors from src/shared/errors.ts with the
+  original error as the cause.
+- All async functions must have explicit error handling.
+- Tests use Arrange-Act-Assert with section comments.
+```
+
+### 4. Commands
+
+Exact commands to build, test, lint, and run the project.
+
+```
+- Install: `npm install`
+- Run all tests: `npm test`
+- Run single test: `npm test -- --grep "test name"`
+- Lint: `npm run lint` (auto-fix: `npm run lint:fix`)
+- Type check: `npx tsc --noEmit`
+- Dev server: `npm run dev` (port 3000, requires local Postgres)
+```
+
+### 5. Constraints
+
+Tell the agent what NOT to do. Prohibitions close shortcuts and force correct approaches.
+
+```
+- Do NOT use `db.query()` directly. Use the repository for that domain.
+- Do NOT put business logic in route handlers.
+- Do NOT import from another domain's internal files.
+- Do NOT use console.log. Use the structured logger.
+- Do NOT commit directly to main.
+```
+
+### 6. Context Guidance
+
+Point to where things are without bloating the file.
+
+```
+- Architecture rules: .harness/architecture.json
+- API design conventions: docs/api-conventions.md
+- Shared types and interfaces: src/shared/
+- Environment configuration: src/config/env.ts
+```
+
+## The 60-Line Rule
+
+Keep CLAUDE.md under 60 lines. Under 80 is acceptable. Over 100, move content elsewhere.
+
+**Why:**
+
+- Frontier models follow ~150-200 discrete instructions with reasonable consistency. Beyond that, compliance degrades.
+- When everything is important, nothing is.
+- Every line takes up context window space the agent needs for reasoning.
+- Research: LLM-generated instruction files degraded performance by 20%+. Hand-crafted files improved performance ~4%.
+
+## The Three-Tier Hierarchy
+
+### Tier 1: Personal (`~/.claude/CLAUDE.md`)
+
+Personal defaults true across all projects. Never checked into version control.
+
+```markdown
+## My Preferences
+
+- Use conventional commit format: type(scope): description
+- Always run tests before considering a task complete.
+- Prefer explicit return types on exported functions.
+- Do not create documentation files unless I specifically ask.
+```
+
+### Tier 2: Project Root (`CLAUDE.md`)
+
+Shared with team. Checked into git. Build commands, architecture rules, naming conventions.
+
+### Tier 3: Subdirectory Files
+
+Domain-specific details. Claude Code loads them when agent works in that directory.
+
+```
+my-project/
+  CLAUDE.md                    ← Always loaded
+  src/
+    billing/
+      CLAUDE.md                ← Loaded when working in billing/
+    notifications/
+      CLAUDE.md                ← Loaded when working in notifications/
+```
+
+**Layering:** Personal loads first → project root → subdirectory. More specific wins on conflict.
+
+## Prohibition-First Thinking
+
+Agents take the shortest path to working code. Without prohibitions:
+
+- Agent puts database query in route handler because it works
+- Agent imports directly from another domain because it works
+- Agent uses deprecated functions because it works
+- Agent creates duplicate utilities because it works
+
+**Prohibitions close these shortcuts.** They force the agent toward the correct approach.
+
+This section grows over time. Each entry corresponds to a real mistake the agent has made.
+
+## Anti-Patterns
+
+| Anti-Pattern                   | Problem                                        | Fix                                     |
+| ------------------------------ | ---------------------------------------------- | --------------------------------------- |
+| **Too long (>100 lines)**      | Each line competes for attention               | Move details to referenced files        |
+| **Too vague**                  | "Write clean code" — can't evaluate compliance | Make every rule machine-testable        |
+| **Missing prohibitions**       | Agent finds creative shortcuts                 | Add "Do NOT" entries for known mistakes |
+| **Contradictory instructions** | Agent picks wrong one                          | Review periodically for consistency     |
+| **Stale instructions**         | Actively point agent wrong                     | Update when project structure changes   |
+| **Ephemeral information**      | Clutter that expires                           | Use PROGRESS.md or issues instead       |

--- a/knowledge/claude-md-sample-kit.md
+++ b/knowledge/claude-md-sample-kit.md
@@ -1,0 +1,120 @@
+# Sample CLAUDE.md Template
+
+A starter CLAUDE.md for projects using harness-kit. Copy this to your project root as `CLAUDE.md` and fill in the project-specific sections.
+
+This template includes kit defaults that agents depend on. Sections marked `<!-- FILL IN -->` need your project details. Sections marked `<!-- KIT DEFAULT -->` work out of the box but can be customized.
+
+---
+
+## Template
+
+```markdown
+# CLAUDE.md
+
+## Tech Stack
+<!-- FILL IN: One paragraph — what the project is, language, framework, key tools, top priority. -->
+
+This is a [DESCRIPTION] built with [LANGUAGE/FRAMEWORK]. [KEY TOOLS/SERVICES].
+[TOP PRIORITY — e.g., reliability, performance, developer experience].
+
+## Architecture
+<!-- FILL IN: 3-5 critical structural rules. Pointer to detailed docs if they exist. -->
+
+- [LAYER STRUCTURE — e.g., routes → services → domain → repositories]
+- [DEPENDENCY RULE — e.g., dependencies flow downward only]
+- [BOUNDARY RULE — e.g., no cross-domain imports]
+- [DATA ACCESS RULE — e.g., database queries only in repository files]
+
+## Commands
+
+| Action | Command |
+|---|---|
+| Install | `TBD` |
+| Build | `TBD` |
+| Test (all) | `TBD` |
+| Test (single) | `TBD` |
+| Lint | `TBD` |
+| Lint (fix) | `TBD` |
+| Type check | `TBD` |
+| Dev server | `TBD` |
+
+<!-- Kit agents read this table. Replace TBD with actual commands. Agents skip TBD entries. -->
+
+## Conventions
+<!-- FILL IN: 5-10 rules your linters don't catch. Each should be machine-evaluable. -->
+
+- Functions: camelCase. Files: kebab-case. Classes: PascalCase.
+- Named exports only. No default exports.
+- Tests use Arrange-Act-Assert with section comments.
+- [ADD YOUR CONVENTIONS]
+
+## Constraints
+<!-- FILL IN: Prohibitions that close shortcuts. Grows over time as the agent makes mistakes. -->
+
+- Do NOT commit directly to main.
+- Do NOT leave TBD entries in code — resolve or create an issue.
+- [ADD YOUR CONSTRAINTS]
+
+## Context Guidance
+
+- Architecture rules: [PATH OR TBD]
+- Shared types/interfaces: [PATH OR TBD]
+- Project standards: standards/
+- Kit knowledge: knowledge/
+
+## Git
+<!-- KIT DEFAULT — customize branch naming and commit style to match your team. -->
+
+- Branch naming: `feature/issue-<number>-<description>`
+- Commit style: conventional commits — `type(scope): description`
+- Co-author line: `Co-Authored-By: Claude <noreply@anthropic.com>`
+
+## Error Protocol
+<!-- KIT DEFAULT — the three-strikes rule agents follow when a task fails. -->
+
+When a task or command fails:
+
+1. **Strike 1:** Read the error message. Identify the root cause. Fix and retry.
+2. **Strike 2:** Try a different approach. Do not repeat the same fix.
+3. **Strike 3:** Stop. Report the failure with what was tried and what failed.
+
+Do not retry more than three times. Do not loop on the same error.
+
+## Agent Model Assignments
+<!-- KIT DEFAULT — which models run which agents. Adjust based on your Anthropic plan. -->
+
+| Agent | Model | Rationale |
+|---|---|---|
+| prep-agent | haiku | Fast, low-cost setup tasks |
+| plan-agent | opus | Deep analysis needs strongest reasoning |
+| implement-agent | (default) | Inherits from session model |
+| code-review-agent | (default) | Inherits from session model |
+
+## Code Review
+<!-- FILL IN or create standards/code-review.md for detailed review criteria. -->
+
+Severity levels:
+
+| Severity | Action Required |
+|---|---|
+| Critical | Must fix before merge |
+| High | Must fix before merge |
+| Medium | Fix if straightforward |
+| Low | Note for future |
+
+Focus areas: [ADD PROJECT-SPECIFIC FOCUS AREAS OR SEE standards/code-review.md]
+
+File categorization: [ADD RULES OR SEE standards/code-review.md]
+```
+
+---
+
+## Usage Notes
+
+- **Keep it under 60 lines** once filled in. Move detailed content to referenced files.
+- **Commands table is critical** — every kit agent reads it. TBD entries are skipped, but missing entries cause agents to guess.
+- **Error protocol and git conventions** are referenced by name in kit agents. Changing section names will break agent references.
+- **Agent model assignments** can be removed if you want all agents to inherit the session model.
+- The template is intentionally longer than 60 lines to include guidance comments. Strip the `<!-- comments -->` in your final version.
+- See `knowledge/claude-md-kit.md` for the full best practices guide.
+- See `knowledge/sample-files-kit.md` for tech-stack-specific examples (TypeScript/React, Python/FastAPI, Monorepo).

--- a/knowledge/concepts-kit.md
+++ b/knowledge/concepts-kit.md
@@ -1,0 +1,115 @@
+# Core Concepts
+
+The foundational ideas from _Harness Engineering for Vibe Coders_ that the CLI encodes.
+
+## The Formula
+
+**Agent = Model + Harness**
+
+- **Model**: Intelligence (constant at any given time)
+- **Harness**: Everything else — constraints, tools, memory, verification, context curation, governance
+
+If you're not the model, you're the harness.
+
+## The Vibe Coding Wall
+
+Vibe coding (describing features in natural language for AI agents to build) works beautifully for small projects (~500-1,000 lines) but hits a predictable wall at **2,000-5,000 lines**. The problem isn't the AI. The problem is the environment.
+
+**Honeymoon Phase (500-1,000 lines):**
+
+- Everything fits in context window
+- No contradictions exist yet
+- Blast radius of mistakes is tiny
+
+**At the Wall:**
+
+- Repetition: Agent duplicates code across files
+- Contradiction: Agent makes conflicting architectural choices
+- Phantom completion: Agent declares work done that doesn't actually work
+- Cascade failure: Fixing one bug introduces others
+
+## Harness Engineering Definition
+
+The discipline of building a structured environment around an AI agent. Components:
+
+- Documentation that tells the agent how your project works
+- Architecture that constrains the solution space
+- Tests and linters providing automated feedback
+- Memory systems persisting decisions across sessions
+- Quality gates verifying agent output before acceptance
+
+## Three Eras of AI-Assisted Development
+
+| Era                                   | Core Question                              | Innovation                                                         | Limitation                                 |
+| ------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------ |
+| **1: Prompt Engineering** (2023-2024) | "What should I tell the model?"            | Single-turn task quality                                           | Nothing linking responses together         |
+| **2: Context Engineering** (2025)     | "What should the model see?"               | Optimized input window (RAG, AGENTS.md, tools)                     | Can show docs but can't enforce compliance |
+| **3: Harness Engineering** (2026)     | "How should the whole system be designed?" | Quality gates, verification loops, constraints, session management | Each era subsumes the previous             |
+
+## The Eight Failure Modes
+
+Every agent failure maps to one of these. Each has a mechanical cause and a structural fix.
+
+| #   | Failure Mode                        | Cause                                                     | Fix Category                      |
+| --- | ----------------------------------- | --------------------------------------------------------- | --------------------------------- |
+| 1   | **Context Overflow**                | Project exceeds context window capacity                   | Context management                |
+| 2   | **Convention Drift**                | No persistent record of conventions                       | Documentation + linters           |
+| 3   | **Copy-Paste Explosion**            | Agent unaware of existing utilities (8x duplication rate) | Architecture + documentation      |
+| 4   | **Phantom Completions**             | Agent judges plausibility, not correctness                | Back-pressure (tests, linters)    |
+| 5   | **Fixation Loop**                   | Local changes without global awareness                    | Automated test suites             |
+| 6   | **Architecture Erosion**            | Architecture invisible unless encoded                     | Linters and CI gates              |
+| 7   | **Blank Slate Problem**             | Agent is stateless across sessions                        | External memory (CLAUDE.md, ADRs) |
+| 8   | **Confidence Without Verification** | Agent presents all output with equal certainty            | External verification             |
+
+**Root cause beneath all eight:** The agent is unsupported — a stateless text generator in an empty environment with no persistent memory, automated verification, enforced constraints, or curated view of the codebase.
+
+## Four Harness Pillars
+
+1. **Documentation/Memory** — CLAUDE.md, ADRs, state files. Fixes: blank slate, convention drift, context overflow
+2. **Architecture/Constraints** — Layered design, linters, CI gates. Fixes: erosion, drift, copy-paste explosion
+3. **Verification/Back-pressure** — Tests, type checkers, linting. Fixes: phantoms, fixation loops, confidence without verification
+4. **Context Management** — What agent sees, when. Fixes: overflow, copy-paste explosion
+
+## Three Enforcement Levels
+
+| Level              | Strength  | Mechanism                                                         |
+| ------------------ | --------- | ----------------------------------------------------------------- |
+| **Documentation**  | Weakest   | Rules in CLAUDE.md; agent tries to follow but skips shortcuts     |
+| **Custom Linters** | Strong    | Scripts that parse code + report violations with fix instructions |
+| **CI/CD Gates**    | Strongest | PR cannot merge if gate fails; ultimate guarantee                 |
+
+All three are needed. Documentation alone is insufficient.
+
+## Evidence That Harness > Model
+
+- **LangChain**: Same model, different harness = 13.7-point benchmark improvement (Top 30 to Top 5)
+- **Vercel**: 15 tools (80% accuracy) to 2 tools (100% accuracy), 37% fewer tokens, 3.5x faster
+- **APEX-Agents**: Frontier models achieve 24% on realistic tasks vs. 90%+ on isolated benchmarks
+- **Separate study**: 78% with harness vs. 42% without (86% improvement from scaffolding alone)
+
+## Counterintuitive Truth: Constraints Improve Performance
+
+- 15 tools: agent wastes tokens deciding which tool to use
+- 2 tools: agent converges directly on the solution
+- Constraints eliminate bad options without eliminating good ones
+- LLM accuracy drops 24%+ when relevant information is embedded in longer contexts
+
+## Six Things the Agent Cannot Provide for Itself
+
+1. **Persistent Memory** — External state (CLAUDE.md, ADRs, progress files)
+2. **Architectural Constraints** — Mechanical enforcement (linter rules, configs)
+3. **Verification Mechanisms** — Back-pressure (tests, type checkers, linters)
+4. **Tool Access** — Expanded capabilities (MCP servers, APIs)
+5. **Context Curation** — Right info at right time (not "more is better")
+6. **Governance** — Boundaries on what agent can/can't do
+
+## Key Mindset Shifts
+
+- "How do I build this?" → "How do I describe this so it gets built correctly?"
+- "Fix the bug" → "Fix the system that allowed the bug"
+- "Write it perfectly" → "Iterate rapidly with quality gates"
+- "I am the coder" → "I am the architect"
+
+## Build for Deletion
+
+Design harness components so they can be cleanly removed when models improve. Constraints compensate for today's limitations; they shouldn't be load-bearing walls.

--- a/knowledge/context-management-kit.md
+++ b/knowledge/context-management-kit.md
@@ -1,0 +1,177 @@
+# Context Management
+
+The invisible skill that separates good from great agent-assisted development.
+
+## Context Window Mechanics
+
+Claude Code operates with ~200,000 tokens of working memory. If it's not in the window, it doesn't exist.
+
+**Token basics:**
+
+- A line of code: ~10 tokens
+- A typical source file: 500-2,000 tokens
+- Full test suite output: 10,000+ tokens
+
+**Before you type your first word**, the agent has already consumed 5,000-15,000 tokens of overhead (system prompt, CLAUDE.md, tool descriptions). Multiple MCP servers can push this to a third of the window.
+
+**Critical finding:** More context isn't better. Performance degrades as context length increases. Models pay most attention to the very beginning and very end. Models advertising 200K windows become unreliable around 130K tokens.
+
+**A 50,000-token session with carefully chosen information will outperform a 150,000-token session stuffed with everything.**
+
+## Context Rot
+
+Gradual degradation of agent output quality as the context window fills. Not a cliff — a slope. No warning; just progressive decline.
+
+**Symptoms:**
+
+1. Agent stops following conventions it followed earlier
+2. Agent re-reads files it already read
+3. Agent contradicts its own earlier decisions
+4. Code quality degrades (correct but generic, not "your" code)
+5. Agent "forgets" the plan
+
+**The insidious part:** Agent never tells you. Output quality drops but presentation doesn't.
+
+## Session Lifecycle
+
+### Four Phases:
+
+1. **Setup** (60 seconds) — Agent reads CLAUDE.md, progress files, checks git status
+2. **Execution** (most of session) — Productive work; context consumed steadily
+3. **Wind-down** (you may not notice) — Context getting full; output getting generic
+4. **Handoff** (most people skip this) — Commit, document, capture state
+
+### Key Principles:
+
+- **One task, one session.** Feature, bug fix, or refactor. One objective per session.
+- **20-minute / one-commit heuristic:** No commit in 20 minutes = something is wrong (task too big, agent stuck, or session stale).
+- **Signs session is stale:** Past 45 minutes on complex work, repeating corrected approaches, re-reading files, writing longer prompts to compensate.
+
+## Compaction
+
+When conversation approaches ~95% capacity, Claude Code summarizes older turns to free space.
+
+**Key:** CLAUDE.md content is never compacted. It sits in the system prompt, always at full fidelity. This is why putting important rules in CLAUDE.md matters so much.
+
+**Use `/compact` manually:**
+
+- Before switching to new phase of work
+- When you notice early context rot signs
+- After long investigation with lots of file reads
+- After resolving a complex bug
+
+**Don't use `/compact`:**
+
+- Mid-complex operation where agent needs full detail
+- Right after giving critical instructions
+- When you're about to end session anyway (just start fresh)
+
+**Anti-pattern:** Re-injecting information after compaction. This fills context faster, triggers more compaction, creates a cycle. If it's important enough to survive compaction, put it in CLAUDE.md or a file.
+
+## The Handoff Problem
+
+### What Gets Lost Between Sessions:
+
+- Full conversation history
+- Every file the agent read
+- Every decision made
+- Agent's understanding of current task state
+
+### What Survives:
+
+- CLAUDE.md (always loaded automatically)
+- The actual codebase (files on disk, git history)
+- Progress files and notes
+- Claude Code's built-in memory system
+
+### Solution 1: Progress Files (Best Mechanism)
+
+```markdown
+# Progress
+
+## Last Updated
+
+2026-03-18, Session 3
+
+## Completed This Session
+
+- Implemented login endpoint (src/routes/auth.ts)
+- Added JWT token generation (src/services/auth-service.ts)
+- Login tests passing (tests/unit/auth-login.test.ts)
+
+## Next Session Should
+
+- Implement password reset flow
+- Add rate limiting to auth endpoints
+
+## Decisions Made
+
+- JWT tokens expire after 1 hour (short-lived for security)
+- Refresh tokens deferred — MVP uses re-login
+
+## Known Issues
+
+- None. Codebase is green.
+```
+
+Write progress files as though the reader has never seen the project before and needs to start work in 60 seconds.
+
+### Solution 2: Descriptive Git Commits
+
+```
+# Good
+a3f2c1d Add password reset confirmation endpoint
+b8e4f5a Implement reset token generation and email stub
+
+# Bad
+a3f2c1d fix stuff
+b8e4f5a updates
+```
+
+### Solution 3: TODO Files
+
+```markdown
+# TODO
+
+## Current Sprint
+
+- [x] User registration endpoint
+- [x] Login with JWT
+- [ ] Password reset flow
+- [ ] Rate limiting on auth endpoints
+```
+
+## Common Context Leaks
+
+| Leak                                 | Fix                                                                      |
+| ------------------------------------ | ------------------------------------------------------------------------ |
+| Sessions too long without compaction | `/compact` at natural transition points                                  |
+| Prompts include too much background  | Put background in CLAUDE.md or progress file                             |
+| Reading entire large files           | Be surgical: "Read the `processOrder` function" or specific line range   |
+| No subdirectory CLAUDE.md files      | Root CLAUDE.md stays lean; domain-specific conventions in subdirectories |
+| Letting agent explore freely         | Triage first: name the file, function, line number                       |
+| Unfiltered tool output               | Filter: `npm test 2>&1 \| grep -A 5 'FAIL'`                              |
+
+## Fresh Sessions vs. Salvaging
+
+**Start fresh when:**
+
+- Past 45-minute mark on complex work
+- Agent repeating corrected approaches
+- Code quality has dropped
+- Agent re-reading files
+- You're writing longer and longer prompts
+
+**The math:** Five focused sessions produce more and better output than one long marathon. Every single time.
+
+## Cheat Sheet
+
+**Before every session:** Read progress file, check git status, state specific task in first prompt.
+
+**During:** Be specific in prompts, point to specific sections not whole files, filter tool output, use `/compact` when switching phases, watch for context rot.
+
+**At checkpoints:** Commit with descriptive messages, update progress file, decide: continue (compact first) or start fresh.
+
+**When ending:** Commit all changes, update progress file with what was done and what's next.
+
+**Rule of thumb:** If it affects code, put it in a project file. If it affects interaction style, let memory handle it. Files are permanent, context is disposable.

--- a/knowledge/hooks-kit.md
+++ b/knowledge/hooks-kit.md
@@ -1,0 +1,288 @@
+# Hooks and Back-Pressure
+
+How to make verification automatic, not optional.
+
+## Hook System Mechanics
+
+Shell commands that Claude Code runs automatically at specific points in the agent's workflow. Configured in `.claude/settings.json` (project) or `~/.claude/settings.json` (user).
+
+**Hook Types:**
+
+- **PreToolUse** — Runs before agent uses a tool. Non-zero exit = tool use blocked.
+- **PostToolUse** — Runs after agent uses a tool. Non-zero exit = agent sees error and can respond.
+- **Notification** — Runs when agent sends notification.
+
+**Valid Matcher Names:**
+
+Matchers correspond to Claude Code tool names. Use pipe (`|`) to match multiple tools:
+
+- `Edit` — file edit tool
+- `Write` — file write tool
+- `Bash` — shell command tool
+- `Read` — file read tool
+- `Glob` — file pattern matching tool
+- `Grep` — content search tool
+- `Edit|Write` — matches both edit and write (most common for lint/format hooks)
+
+**Note:** `write_to_file` is NOT a valid Claude Code tool name (it belongs to other AI coding tools). Always use `Edit|Write` for file-mutation hooks.
+
+**Hook Environment Variables:**
+
+- `$CLAUDE_PROJECT_DIR` — the project root directory (always available)
+
+File path context is passed via stdin as JSON, not as an environment variable. Hook scripts should parse stdin for file-specific information, or delegate to shell scripts that handle this.
+
+**How they work:**
+
+1. Agent calls a tool (e.g., Edit or Write)
+2. Claude Code checks for matching hooks
+3. Hook command runs with context via stdin JSON
+4. Exit 0 = success, proceed
+5. Non-zero = failure, agent sees error output and can fix
+
+## Concrete Hook Examples
+
+### Lint-on-Save (TypeScript)
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/lint.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Lint-on-Save (Python)
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/ruff-lint.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Format Checker (Prettier)
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/format.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Forbidden File Protection (PreToolUse)
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/protect-files.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Protect Migration Files
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/protect-migrations.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Security Scanner (Hardcoded Secrets)
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/secret-scanner.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Build Verification (TypeScript)
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/typecheck.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Complete Configuration Example
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/protect-files.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/typecheck.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/lint.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/secret-scanner.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Hook Command Convention
+
+- **Project-wide commands** (pre-commit): use `npm run <script>` (e.g., `npm run typecheck`, `npm test`)
+- **Per-file commands** (Claude Code hooks): use `npx <tool>` (e.g., `npx eslint "$FILE_PATH"`)
+- **Never use bare tool names** (e.g., `tsc`) — they depend on global installs and break across environments
+
+## Verification Stack Layers
+
+| Layer                 | Speed           | Catches                                                          | Hook Pattern                          |
+| --------------------- | --------------- | ---------------------------------------------------------------- | ------------------------------------- |
+| **Type Checking**     | Milliseconds    | Syntax errors, type mismatches, missing imports                  | PostToolUse: `tsc --noEmit`           |
+| **Linting**           | Seconds         | Style violations, banned patterns, naming drift                  | PostToolUse: `eslint`, `ruff`         |
+| **Unit Tests**        | Seconds-minutes | Logic errors, wrong return values, missing error handling        | PostToolUse or CLAUDE.md instructions |
+| **Integration Tests** | Minutes         | Layer interaction bugs, DB query issues, API contract violations | CLAUDE.md: run before committing      |
+| **Human Review**      | Variable        | Architectural drift, unnecessary complexity, wrong approach      | PR process                            |
+
+## Test-Driven Back-Pressure
+
+The red-green workflow:
+
+1. Write tests (or have agent write them, then review)
+2. Run tests — they fail (red)
+3. Tell agent: "Make these tests pass"
+4. Agent implements, runs tests, self-corrects on failure
+5. All tests pass (green) — done
+
+## Pre-Commit Hook as Safety Net
+
+```bash
+#!/bin/bash
+# .git/hooks/pre-commit
+set -e
+
+echo "Running pre-commit checks..."
+echo "  Type checking..."
+npx tsc --noEmit 2>&1 | grep -i "error" && exit 1 || true
+
+echo "  Linting..."
+npx eslint src/ --format compact 2>&1 | grep -i "error" && exit 1 || true
+
+echo "  Running tests..."
+CHANGED=$(git diff --cached --name-only --diff-filter=ACMR | grep 'src/' | head -20)
+if [ -n "$CHANGED" ]; then
+  PATTERNS=$(echo "$CHANGED" | sed 's|src/||' | sed 's|\.ts$||' | tr '\n' '|' | sed 's/|$//')
+  npx jest --testPathPattern="$PATTERNS" --silent 2>&1 | grep -A 5 'FAIL\|Error' && exit 1 || true
+fi
+
+echo "All pre-commit checks passed."
+```
+
+## Filtering Output (Keep Context Clean)
+
+```bash
+# TypeScript — errors only
+npx tsc --noEmit 2>&1 | grep -E "^src/.*error TS" | head -20
+
+# ESLint — compact format
+npx eslint "$FILE" --format compact 2>&1 | head -30
+
+# Jest — failures only
+npx jest --testPathPattern="$MODULE" --silent 2>&1 | grep -A 5 'FAIL\|Error\|✗'
+
+# Pytest — short summary
+python -m pytest tests/ -q --tb=short 2>&1 | grep -E "FAILED|ERROR" -A 10
+```

--- a/knowledge/sample-files-kit.md
+++ b/knowledge/sample-files-kit.md
@@ -1,0 +1,400 @@
+# Sample Files
+
+Reference examples of well-built harness components. The CLI uses these as templates and comparison targets.
+
+## Example CLAUDE.md: TypeScript/React (41 lines)
+
+```markdown
+# CLAUDE.md
+
+## Overview
+
+React 18 SPA with TypeScript. Uses Vite for builds, Zustand for state
+management, React Query for server state. Talks to a REST API at /api.
+
+## Build & Test
+
+- Install: `npm install`
+- Dev server: `npm run dev` (port 5173)
+- Tests: `npm test` (Vitest)
+- Single test: `npx vitest run path/to/test.ts`
+- Lint: `npm run lint`
+- Type check: `npx tsc --noEmit`
+- Build: `npm run build`
+
+## Project Structure
+
+- src/features/ — Feature modules (each has components/, hooks/, api/)
+- src/shared/ — Shared components, hooks, utilities
+- src/config/ — App configuration and constants
+- src/types/ — Shared TypeScript types
+- tests/ — Mirrors src/ structure
+
+## Conventions
+
+- Components: PascalCase files and function names. One component per file.
+- Hooks: camelCase, prefixed with `use`. Custom hooks in hooks/ directory.
+- Named exports only. No default exports.
+- Use `cn()` utility from src/shared/utils for combining CSS classes.
+- Forms use react-hook-form with zod schemas for validation.
+- API calls go through React Query hooks in feature's api/ directory.
+
+## Architecture
+
+- Feature modules are self-contained. No cross-feature imports.
+- Shared code goes in src/shared/. If two features need it, it's shared.
+- State: local with useState, shared with Zustand stores,
+  server state with React Query. Never mix these.
+- Route definitions live in src/routes.tsx. One entry per feature.
+
+## Do NOT
+
+- Do NOT use `any` type. Use `unknown` and narrow, or define a proper type.
+- Do NOT put API URLs as string literals. Use constants from src/config/api.ts.
+- Do NOT manipulate the DOM directly. Use refs when necessary.
+- Do NOT create new Zustand stores without discussing scope first.
+- Do NOT use index files (index.ts) for re-exports. Import directly.
+```
+
+## Example CLAUDE.md: Python/FastAPI (38 lines)
+
+```markdown
+# CLAUDE.md
+
+## Overview
+
+FastAPI REST API with SQLAlchemy ORM and PostgreSQL. Serves a React
+frontend. Uses Alembic for migrations. Python 3.12+.
+
+## Build & Test
+
+- Setup: `pip install -e ".[dev]"` (use virtual env)
+- Tests: `pytest` (all) or `pytest tests/test_specific.py` (single)
+- Lint: `ruff check .` (fix: `ruff check --fix .`)
+- Format: `ruff format .`
+- Type check: `mypy src/`
+- Run server: `uvicorn src.main:app --reload`
+- Migrations: `alembic upgrade head` (apply),
+  `alembic revision --autogenerate -m "description"` (create)
+
+## Structure
+
+- src/domains/ — Business domains (users/, billing/, projects/)
+- src/domains/\*/models.py — SQLAlchemy models
+- src/domains/\*/schemas.py — Pydantic request/response schemas
+- src/domains/\*/router.py — FastAPI route definitions
+- src/domains/\*/service.py — Business logic
+- src/domains/\*/repository.py — Database queries
+- src/core/ — Shared config, deps, exceptions, middleware
+
+## Conventions
+
+- Type hints on all function signatures. No bare `dict` or `list`.
+- Pydantic models for all API inputs and outputs. Never return raw dicts.
+- Dependency injection via FastAPI `Depends()` for DB sessions and auth.
+- Exceptions: raise from src/core/exceptions.py. Never return error dicts.
+- Tests: use pytest fixtures. Factories in tests/factories.py.
+
+## Do NOT
+
+- Do NOT use raw SQL. Use SQLAlchemy ORM methods via the repository.
+- Do NOT access `request.state` directly. Use dependency injection.
+- Do NOT create circular imports between domains. Use events or shared schemas.
+- Do NOT write business logic in router.py. Routers call services. Period.
+- Do NOT use `from src.domains.users.models import User` in another domain.
+```
+
+## Example CLAUDE.md: Monorepo Root (28 lines)
+
+```markdown
+# CLAUDE.md
+
+## Overview
+
+Monorepo managed with Turborepo. Three packages: web (React), api
+(Express), and shared (common types and utilities).
+
+## Build & Test
+
+- Install: `npm install` (from root — workspaces handle packages)
+- Build all: `npx turbo build`
+- Test all: `npx turbo test`
+- Build one: `npx turbo build --filter=@project/api`
+- Test one: `npx turbo test --filter=@project/web`
+- Lint all: `npx turbo lint`
+
+## Structure
+
+- packages/web/ — React frontend (see packages/web/CLAUDE.md)
+- packages/api/ — Express backend (see packages/api/CLAUDE.md)
+- packages/shared/ — Shared types, validators, constants
+- turbo.json — Pipeline configuration
+
+## Cross-Package Rules
+
+- packages/shared/ is the ONLY package others can import from.
+- web and api must NEVER import from each other.
+- Shared types go in packages/shared/src/types/.
+- When changing shared types, run `npx turbo build` to verify downstream.
+- All cross-package imports use @project/ scope: `@project/shared`.
+
+## Git
+
+- Branches: feature/package-name/description
+- Commits: type(package): description (e.g., feat(api): add user endpoint)
+- Run `npx turbo test --filter=...` for affected packages before committing.
+```
+
+## Example Subdirectory CLAUDE.md (11 lines)
+
+```markdown
+# packages/api/CLAUDE.md
+
+## API-Specific Rules
+
+- Express routes go in src/routes/. One file per resource.
+- Middleware goes in src/middleware/. Auth middleware is already set up.
+- Database access: use Prisma client from src/db/client.ts.
+- Response format: always use helpers from src/utils/response.ts.
+  Never send raw `res.json()`.
+- Error handling: throw from src/errors/. Error middleware catches them.
+- Migrations: `npx prisma migrate dev --name description`
+- Generate types after schema changes: `npx prisma generate`
+```
+
+## Example Personal ~/.claude/CLAUDE.md (10 lines)
+
+```markdown
+# ~/.claude/CLAUDE.md
+
+## Personal Preferences
+
+- Use conventional commits: type(scope): description
+- Run tests before telling me a task is complete.
+- Prefer explicit return types on exported functions.
+- Prefer functional patterns over class-based unless codebase uses classes.
+- Do not create README.md or documentation files unless I ask.
+- Do not add comments explaining obvious code. Only comment the "why."
+- When I say "refactor," I mean restructure without changing behavior.
+- Keep git diffs minimal. Don't reformat files you didn't need to change.
+```
+
+## Example .claude/settings.json (Complete)
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Glob",
+      "Grep",
+      "Edit",
+      "Write",
+      "Bash(npm test*)",
+      "Bash(npm run lint*)",
+      "Bash(npm run build*)",
+      "Bash(npx tsc*)",
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git add*)",
+      "Bash(git commit*)",
+      "Bash(ls *)",
+      "Bash(curl http://localhost*)"
+    ],
+    "deny": [
+      "Bash(curl*POST*)",
+      "Bash(rm -rf*)",
+      "Bash(npm publish*)",
+      "Bash(docker*)",
+      "Bash(ssh*)",
+      "Read(**/.env*)",
+      "Read(~/.ssh/*)",
+      "Read(~/.aws/*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "write_to_file",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'BLOCKED=\".env .env.local package-lock.json\"; for f in $BLOCKED; do if [[ \"$CLAUDE_FILE_PATH\" == *\"$f\" ]]; then echo \"BLOCKED: $f is protected.\" >&2; exit 1; fi; done'"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "write_to_file",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'if [[ \"$CLAUDE_FILE_PATH\" == *.ts ]]; then npx tsc --noEmit 2>&1 | grep -E \"^src/.*error TS\" | head -15; fi'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'if [[ \"$CLAUDE_FILE_PATH\" == *.ts ]] || [[ \"$CLAUDE_FILE_PATH\" == *.js ]]; then npx eslint --fix \"$CLAUDE_FILE_PATH\" --format compact 2>&1 | head -20; fi'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'if grep -nEi \"(api_key|secret|password|token)\\s*[:=]\\s*[\\x27\\\"][A-Za-z0-9]{8,}\" \"$CLAUDE_FILE_PATH\" 2>/dev/null; then echo \"Possible hardcoded secret.\" >&2; exit 1; fi'"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Example .harness/architecture.json
+
+```json
+{
+  "version": "1.0",
+  "layers": {
+    "presentation": {
+      "path": "src/routes/",
+      "description": "HTTP route handlers — parse request, delegate, format response",
+      "canDependOn": ["application"]
+    },
+    "application": {
+      "path": "src/services/",
+      "description": "Use cases and business logic orchestration",
+      "canDependOn": ["domain", "infrastructure"]
+    },
+    "domain": {
+      "path": "src/domain/",
+      "description": "Business rules, entities, value objects — zero external dependencies",
+      "canDependOn": []
+    },
+    "infrastructure": {
+      "path": "src/repositories/",
+      "description": "Database access and external API clients",
+      "canDependOn": ["domain"]
+    }
+  },
+  "domains": {
+    "users": "src/features/users/",
+    "billing": "src/features/billing/",
+    "notifications": "src/features/notifications/"
+  },
+  "crossDomainRule": "No direct cross-domain imports. Use shared/interfaces/.",
+  "sharedPath": "src/shared/",
+  "bannedPatterns": [
+    {
+      "pattern": "db\\.query|\\.(execute|raw)\\(",
+      "excludePaths": ["src/repositories/", "src/config/", "migrations/"],
+      "message": "Direct database queries must go through repository layer",
+      "severity": "critical"
+    },
+    {
+      "pattern": "process\\.env",
+      "excludePaths": ["src/config/"],
+      "message": "Access environment variables through src/config/ only",
+      "severity": "important"
+    },
+    {
+      "pattern": "console\\.log",
+      "excludePaths": ["scripts/", "tests/"],
+      "message": "Use structured logger from src/shared/logger instead",
+      "severity": "recommended"
+    },
+    {
+      "pattern": "TODO|FIXME|HACK",
+      "excludePaths": [],
+      "message": "Track issues in issue tracker, not code comments",
+      "severity": "recommended"
+    }
+  ],
+  "fileRules": {
+    "maxLines": 300,
+    "namingConvention": "kebab-case",
+    "typeSuffixes": {
+      "service": ".service.ts",
+      "repository": ".repository.ts",
+      "routes": ".routes.ts",
+      "types": ".types.ts",
+      "test": ".test.ts"
+    }
+  }
+}
+```
+
+## Example Progress File
+
+```markdown
+# Progress
+
+## Last Updated
+
+2026-03-18, Session 3
+
+## Completed This Session
+
+- Implemented login endpoint (src/routes/auth.ts)
+- Added JWT token generation (src/services/auth-service.ts)
+- Wired up password hashing with bcrypt
+- Login tests passing (tests/unit/auth-login.test.ts)
+
+## Next Session Should
+
+- Implement password reset flow (email + token)
+- Add rate limiting to auth endpoints
+- Wire up real SMTP via SendGrid (API key in .env)
+
+## Decisions Made
+
+- JWT tokens expire after 1 hour (short-lived for security)
+- Login returns { token, expiresIn } — no user profile in response
+- Refresh tokens deferred — MVP uses re-login
+
+## Known Issues
+
+- None. Codebase is green.
+```
+
+## Example Architecture Linter Script
+
+```bash
+#!/bin/bash
+# scripts/check-architecture.sh
+ERRORS=0
+
+# No database calls outside repositories
+DB_VIOLATIONS=$(grep -rn "db\.\|\.query(\|\.execute(" src/ \
+  | grep -v "src/repositories/" \
+  | grep -v "src/config/" || true)
+if [ -n "$DB_VIOLATIONS" ]; then
+    echo "ERROR: Database queries found outside repository layer:"
+    echo "$DB_VIOLATIONS"
+    echo "FIX: Move database queries to the appropriate repository."
+    ERRORS=$((ERRORS + 1))
+fi
+
+# No direct env access outside config
+ENV_VIOLATIONS=$(grep -rn "process\.env" src/ \
+  | grep -v "src/config/" || true)
+if [ -n "$ENV_VIOLATIONS" ]; then
+    echo "ERROR: Direct environment variable access outside config:"
+    echo "$ENV_VIOLATIONS"
+    echo "FIX: Import config values from src/config/ instead."
+    ERRORS=$((ERRORS + 1))
+fi
+
+# No cross-domain imports
+for domain in users billing notifications; do
+  CROSS=$(grep -rn "from.*src/features/" "src/features/$domain/" \
+    | grep -v "src/features/$domain/" \
+    | grep -v "src/shared/" || true)
+  if [ -n "$CROSS" ]; then
+    echo "ERROR: Cross-domain import in $domain/:"
+    echo "$CROSS"
+    echo "FIX: Use shared/interfaces/ for cross-domain access."
+    ERRORS=$((ERRORS + 1))
+  fi
+done
+
+exit $ERRORS
+```

--- a/knowledge/subagents-kit.md
+++ b/knowledge/subagents-kit.md
@@ -1,0 +1,161 @@
+# Sub-Agents and Planning
+
+Task decomposition, context firewalls, and parallel execution.
+
+## Sub-Agent Mechanics
+
+When a sub-agent spins up:
+
+1. Gets fresh context window (no conversation history)
+2. Gets only what parent passes: task description, specific files, desired output format
+3. Has access to same filesystem and tools as parent
+4. Reads CLAUDE.md independently
+5. Returns single result — all work distilled into return message
+
+**High input, low output:** Sub-agent might read 20 files. Parent only sees a 500-token summary instead of absorbing 18,000 tokens.
+
+## Context Firewalls
+
+| Direction                  | What Crosses                                               |
+| -------------------------- | ---------------------------------------------------------- |
+| **Parent → Sub-agent**     | Task description, specific context, desired output format  |
+| **Sub-agent → Parent**     | Condensed result, artifacts created (files, commits)       |
+| **Stays inside sub-agent** | All file reads, search results, reasoning steps, dead ends |
+
+**Why isolation helps:**
+
+- Mistakes in one sub-agent don't pollute others
+- Parent stays focused on coordination
+- Sub-agents can be right-sized to task
+- After 3 research tasks: 1,500 tokens of summaries vs. 45,000 without sub-agents
+
+## Planning-First Workflow
+
+**Always plan before code.**
+
+### Step 1: Ask for a plan
+
+```
+Plan how you'd add user authentication to this app. Read the
+existing codebase first. Tell me what approach, which files,
+implementation steps. Don't write any code yet.
+```
+
+### Step 2: Review and adjust
+
+```
+Use argon2 for hashing, not bcrypt. Middleware should be
+route-level, not app-level.
+```
+
+Plan becomes a contract. Once approved, agent has clear boundaries.
+
+### Step 3: Execute step by step
+
+```
+Execute step 1: create the User entity following our base
+entity pattern. Run the typecheck when done.
+```
+
+Review each step before moving to the next. Catches misalignment early.
+
+**Why it works:**
+
+- Without plan: agent makes 50 micro-decisions, presents finished implementation. Wrong decisions found in pile of code.
+- With plan: see decisions before they become code. Wrong decisions caught cheaply.
+- Plan is a recovery document — if session dies, next session knows what's done and what remains.
+
+## Task Decomposition
+
+### Agent-Sized Task Properties:
+
+1. **Self-contained** — Can complete without asking questions
+2. **Verifiable** — Clear success criteria (test passes, build succeeds)
+3. **Scoped** — Touches bounded set of files, ideally one module
+4. **Independent** — Doesn't conflict with simultaneous tasks
+
+### Example Decomposition:
+
+**Vibe coding:** "Implement task assignment"
+
+**Decomposed:**
+
+1. Add assigneeId field to Task entity
+2. Create assignTask method in task service with validation
+3. Add PUT endpoint for task assignment
+4. Write unit tests for assignTask service method
+5. Write e2e test for full assignment flow
+
+Five bounded, verifiable tasks. Fewer decisions per task = fewer wrong decisions.
+
+### Vertical Slices > Horizontal Layers
+
+**Horizontal** (by layer): All entities, then all services, then all routes. Creates dependencies.
+
+**Vertical** (by feature): Entity + service + route + test for ONE piece at a time. Each task self-contained and independently verifiable.
+
+## Git Worktree Parallelization
+
+Multiple Claude Code sessions need physical isolation. Git worktrees provide separate working copies.
+
+```bash
+git worktree add ../project-auth feature/add-authentication
+git worktree add ../project-notifications feature/add-notifications
+git worktree add ../project-search feature/add-search
+```
+
+Three directories, each on own branch. Launch Claude Code in each. Agents can't interfere.
+
+**When parallelization helps:** Tasks clearly independent, each well-specified, clean module boundaries, mature CLAUDE.md.
+
+**When it adds complexity:** Tasks share files, specs are vague, codebase tightly coupled, no automated verification.
+
+## Sub-Agent Patterns
+
+### Research-Then-Build
+
+```
+Use a sub-agent to research how payments are handled in this
+codebase. Return: which files, what the flow looks like, what
+patterns to follow when adding a new payment type.
+```
+
+Then plan with the research results. Two steps: research in isolation, planning with clean summary.
+
+### Architect-Plus-Builder
+
+Parent handles architecture/decisions. Sub-agents handle implementation.
+
+```
+Delegate step 1 to a sub-agent: create the Notification entity
+following our base entity pattern. Write tests and confirm they
+pass. Return file paths and summary.
+```
+
+### Test Analysis
+
+```
+Delegate to sub-agent: run full test suite and summarize what's
+passing, failing, and why. Categorize failures. Don't fix, just report.
+```
+
+Gets actionable info in ~200 tokens instead of 10,000 tokens of raw output.
+
+## Common Mistakes
+
+| Mistake                            | Fix                                                                                       |
+| ---------------------------------- | ----------------------------------------------------------------------------------------- |
+| Marathon sessions                  | Break into focused chunks; fresh session after each major task                            |
+| Not planning before coding         | Always "plan this before writing code"                                                    |
+| Over-decomposing simple tasks      | If task adds <1,000 tokens to context, do inline                                          |
+| Not reviewing intermediate results | Execute one step, review, confirm, then move to next                                      |
+| Sub-agents duplicating work        | Write precise task descriptions with specific scope, files, output format, and boundaries |
+
+## Complete Workflow Pattern
+
+1. **Plan the feature** — Decompose into steps, review/adjust
+2. **Identify parallelism** — Which steps independent? Which sequential?
+3. **Execute sequential first** — Shared foundations (entities, interfaces)
+4. **Fan out to parallel sub-agents** — Independent tasks with foundation in place
+5. **Review and integrate** — Check each sub-agent summary and modified files
+6. **Checkpoint** — Commit, update progress, start next feature fresh

--- a/knowledge/tools-and-trust-kit.md
+++ b/knowledge/tools-and-trust-kit.md
@@ -1,0 +1,164 @@
+# Tools and Trust
+
+Permission modes, trust zones, MCP servers, and the "fewer tools, better results" principle.
+
+## Three-Zone Trust Model
+
+| Zone                    | Access               | Examples                                                                                  |
+| ----------------------- | -------------------- | ----------------------------------------------------------------------------------------- |
+| **Zone 1: Full Access** | Read + write         | Working source code, test suite, local dev DB, build tooling                              |
+| **Zone 2: Read-Only**   | Reference only       | Production configs, shared type definitions, internal docs, dependency manifests          |
+| **Zone 3: No Access**   | Mechanically blocked | Production databases, secret stores, deployment pipelines, customer data, payment systems |
+
+**Critical:** Zone 3 boundaries must be mechanically enforced. "Don't access production database" in CLAUDE.md is instructional. No credentials = mechanical boundary.
+
+## Permission Modes
+
+- **Default**: Agent asks before potentially destructive operations. Safest starting point.
+- **Auto-allow with rules**: Patterns for auto-approved operations. `npm test` runs without asking; `rm -rf` needs approval.
+- **Fully permissive**: Everything runs without asking. Only for sandboxed environments or CI/CD.
+
+**Principle:** Start restrictive, open up as needed.
+
+## Permission Configuration Examples
+
+### Web App (Balanced)
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Glob",
+      "Grep",
+      "Edit",
+      "Write",
+      "Bash(npm test*)",
+      "Bash(npm run lint*)",
+      "Bash(npm run build*)",
+      "Bash(npx tsc*)",
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git add*)",
+      "Bash(git commit*)",
+      "Bash(ls *)",
+      "Bash(curl http://localhost*)"
+    ],
+    "deny": [
+      "Bash(curl*POST*)",
+      "Bash(rm -rf*)",
+      "Bash(npm publish*)",
+      "Bash(docker*)",
+      "Bash(ssh*)",
+      "Read(**/.env*)",
+      "Read(~/.ssh/*)",
+      "Read(~/.aws/*)"
+    ]
+  }
+}
+```
+
+### API Service (Tighter)
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Glob",
+      "Grep",
+      "Edit(src/**)",
+      "Edit(tests/**)",
+      "Write(src/**)",
+      "Write(tests/**)",
+      "Bash(go test*)",
+      "Bash(go build*)",
+      "Bash(go vet*)",
+      "Bash(make lint*)",
+      "Bash(git *)",
+      "Bash(ls *)"
+    ],
+    "deny": [
+      "Write(deploy/**)",
+      "Write(infrastructure/**)",
+      "Write(Makefile)",
+      "Bash(docker push*)",
+      "Bash(kubectl*)",
+      "Bash(terraform*)",
+      "Bash(curl*POST*)",
+      "Bash(curl*PUT*)",
+      "Bash(curl*DELETE*)",
+      "Read(**/.env*)",
+      "Read(~/.kube/*)"
+    ]
+  }
+}
+```
+
+## "Fewer Tools, Better Results" — The Vercel Finding
+
+Vercel built an analytics agent with 15 specialized tools, then stripped to bash + standard Unix utilities.
+
+| Metric              | 15 Tools | Bash Only  |
+| ------------------- | -------- | ---------- |
+| Accuracy            | 80%      | **100%**   |
+| Token usage (worst) | 145,000  | **67,000** |
+| Steps (worst)       | 100      | **19**     |
+| Speed (worst)       | 724s     | **141s**   |
+
+**Why fewer tools work better:**
+
+- Every tool is a decision the agent must make
+- Tool descriptions consume context (15 tools = 5,000-10,000 tokens)
+- Specialized tools overlap, creating fuzzy boundaries
+- General tools (bash) are self-correcting
+
+**Rule:** Start with zero extra tools. Add one when there's a specific, repeated need.
+
+**Tools that commonly earn their place:** Database query (read-only), browser automation (Playwright), GitHub integration, error monitoring (Sentry).
+
+**Tools that rarely earn their place:** Slack, email, calendar, git MCP wrappers, generic HTTP tools, filesystem MCP servers.
+
+## MCP Server Configuration
+
+```json
+{
+  "mcpServers": {
+    "postgres": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-postgres"],
+      "env": {
+        "DATABASE_URL": "${DEV_DATABASE_URL}"
+      }
+    }
+  }
+}
+```
+
+**Critical:** Always use `${VAR}` syntax for credentials. Never hardcode.
+
+## Tool Poisoning Risks
+
+Malicious tool descriptions can influence agent behavior. A tool description can instruct the agent to read sensitive files and include them in parameters.
+
+**How to vet MCP servers:**
+
+1. Read the source code — if not open source, don't install
+2. Check every tool description for suspicious instructions
+3. Monitor network traffic on first run
+4. Pin versions and audit updates
+5. Prefer official/well-known servers
+
+**Risk:** A single malicious server can influence how the agent interacts with legitimate servers in the same session.
+
+## Common Trust Leaks
+
+| Leak                                   | Fix                                                                            |
+| -------------------------------------- | ------------------------------------------------------------------------------ |
+| Agent has production DB access         | Use `DEV_DATABASE_URL`; create read-only DB user for agent                     |
+| No file modification restrictions      | Scope writes: `Write(src/**)`, deny: `Write(deploy/**)`                        |
+| Secrets in environment variables       | Separate shell profile for agent sessions; deny `Bash(env)`, `Bash(printenv)`  |
+| Hardcoded credentials in .mcp.json     | Always use `${VARIABLE_NAME}` syntax; pre-commit hook scanning for credentials |
+| Too many MCP servers consuming context | Ruthlessly remove unused servers; consider task-specific configurations        |

--- a/standards/code-review.md
+++ b/standards/code-review.md
@@ -1,0 +1,59 @@
+# Code Review Standard
+
+## Scope
+
+This standard defines how code reviews are evaluated for the Checked Out project.
+Customize the criteria below to match your team's priorities.
+
+## Severity Levels
+
+| Level | Meaning | Action Required |
+| --- | --- | --- |
+| **Critical** | Breaks functionality, security vulnerability, data loss risk | Must fix before merge |
+| **Major** | Architectural violation, missing error handling, untested path | Should fix before merge |
+| **Minor** | Style inconsistency, naming, missing docs | Fix if convenient |
+| **Nit** | Preference, suggestion, optional improvement | Author's discretion |
+
+## Evaluation Criteria
+
+### Architecture
+- Follows 3-tier separation: routes -> controllers -> services -> models
+- No business logic in controllers or route handlers
+- No direct database queries outside models/services
+- No cross-layer imports that skip levels
+
+### Code Quality
+- DRY: No duplicated logic (extract to service or utility)
+- KISS: Simplest solution that meets requirements
+- SOLID: Single responsibility per file/function
+- Error handling: All async operations have try/catch or .catch()
+- No console.log in production code (use structured logger)
+
+### Testing
+- New features have corresponding test coverage
+- API endpoints tested with real database (no mocks for integration tests)
+- Edge cases covered (empty input, invalid data, not found)
+
+### Security
+- No hardcoded credentials or API keys
+- SQL injection protected (use parameterized queries / Sequelize ORM)
+- Input validation on all user-facing endpoints
+- No XSS vulnerabilities in frontend (sanitize user content)
+
+### Frontend
+- PropTypes defined for all components
+- Material UI theme used (no inline color/spacing values)
+- Responsive design considered
+- Accessibility basics (alt text, aria labels, semantic HTML)
+
+### Documentation
+- Complex logic has explanatory comments (why, not what)
+- API endpoints documented with request/response examples
+- Migration files have descriptive names
+
+## Review Output
+
+Reviews should produce:
+1. Summary of changes reviewed
+2. List of findings by severity
+3. Overall recommendation: Approve / Request Changes / Needs Discussion

--- a/standards/full/harness-standard-kit.md
+++ b/standards/full/harness-standard-kit.md
@@ -1,0 +1,233 @@
+# Harness Maturity Standard — Full Reference
+
+## Overview
+
+The harness maturity model defines four tiers that describe how well a project's structured environment supports AI coding agents. The model is implemented as audit rules in `harness-cli` — each rule is assigned to the minimum tier that requires it.
+
+The formula: **Agent = Model + Harness**. The model is a constant. The harness is everything else — instructions, verification, constraints, context management, tools, continuity, and architecture enforcement. This standard describes what a mature harness looks like at each level.
+
+## Maturity Tiers
+
+Tiers are cumulative. A project must achieve all lower tiers before claiming a higher one. A single failing rule at a lower tier blocks achievement of all tiers above it.
+
+### Tier 1: Minimal (2 rules)
+
+**What it means:** The agent has _something_ to work with.
+
+**Requirements:**
+
+| Rule             | Category     | What it checks                                                   |
+| ---------------- | ------------ | ---------------------------------------------------------------- |
+| claude-md-exists | Instructions | A CLAUDE.md file exists at the project root                      |
+| claude-md-length | Instructions | CLAUDE.md contains meaningful content (not empty or single-line) |
+
+**Rationale:** Without a CLAUDE.md file, the agent operates with zero project-specific context. It will guess at conventions, architecture, and constraints — and guess wrong. The Minimal tier sets the absolute floor: the agent can at least read _something_ about the project.
+
+**What this tier does NOT provide:** Any guarantee that the content is useful, specific, or enforced.
+
+---
+
+### Tier 2: Structured (12 rules)
+
+**What it means:** The agent has specific, actionable instructions across all harness pillars.
+
+**Requirements:**
+
+| Rule               | Category     | What it checks                                                       |
+| ------------------ | ------------ | -------------------------------------------------------------------- |
+| has-tech-stack     | Instructions | CLAUDE.md lists the tech stack with specific technologies            |
+| has-architecture   | Instructions | CLAUDE.md describes the project's architecture (directories, layers) |
+| has-constraints    | Instructions | CLAUDE.md specifies what the agent should NOT do                     |
+| specificity        | Instructions | Instructions use concrete file paths and patterns, not vague advice  |
+| subdirectory-files | Instructions | Subdirectory CLAUDE.md files exist where conventions differ by area  |
+| session-scoping    | Context      | CLAUDE.md includes guidance on session scope and focus               |
+| compact-guidance   | Context      | CLAUDE.md includes guidance on using /compact and context management |
+| subagent-guidance  | Context      | CLAUDE.md includes guidance on sub-agent delegation                  |
+| mcp-configured     | Tools        | MCP server configuration exists if the project uses external tools   |
+| mcp-count          | Tools        | MCP server count is reasonable (not over-tooled)                     |
+| config-exists      | Architecture | Architecture configuration file exists (.harness/architecture.json)  |
+| onboarding-quality | Continuity   | Onboarding documentation is sufficient for a new session             |
+
+**Rationale:** Structured projects have invested in telling the agent what to do. The instructions cover the four harness pillars: documentation/memory, architecture/constraints, verification (documented but not yet enforced), and context management. This tier catches the most common failure modes — convention drift, copy-paste explosion, and the blank-slate problem — through documentation alone.
+
+**Key insight:** Documentation is the weakest enforcement level. An agent _tries_ to follow instructions but takes shortcuts, loses context over long sessions, and lacks the ability to verify its own compliance. Structured is necessary but not sufficient.
+
+**Example — Structured but not Verified:**
+
+```
+# CLAUDE.md
+## Testing
+- Run `npm test` before committing
+- All new code must have tests
+```
+
+The agent sees this instruction. Whether it actually runs tests before committing depends on the agent's diligence — there is no mechanical guarantee.
+
+---
+
+### Tier 3: Verified (12 rules)
+
+**What it means:** The harness mechanically enforces its own rules. Documentation is backed by automation.
+
+**Requirements:**
+
+| Rule                   | Category     | What it checks                                             |
+| ---------------------- | ------------ | ---------------------------------------------------------- |
+| hooks-configured       | Verification | Claude Code hooks are configured in .claude/settings.json  |
+| hook-scripts-exist     | Verification | Hook scripts referenced in settings actually exist on disk |
+| lint-hook              | Verification | A PostToolUse hook runs linting after file writes          |
+| test-hook              | Verification | A pre-commit hook runs the test suite                      |
+| forbidden-patterns     | Verification | Hooks or rules block known anti-patterns                   |
+| clear-feedback         | Verification | Failed checks provide clear, actionable error messages     |
+| permissions-configured | Constraints  | Permission settings exist and match risk levels            |
+| deny-rules             | Constraints  | Explicit deny rules prevent dangerous operations           |
+| off-limits-files       | Constraints  | Protected files/directories are defined                    |
+| scope-rules            | Constraints  | Rules limit what the agent can modify                      |
+| banned-patterns        | Architecture | Architecture enforcement detects banned code patterns      |
+| enforcement-level      | Architecture | Enforcement goes beyond documentation to active checking   |
+
+**Rationale:** The gap between Structured and Verified is the gap between _telling_ the agent what to do and _catching it_ when it does not comply. This is the single most impactful tier transition for most projects.
+
+At Verified, the harness embodies the three enforcement levels from the core concepts:
+
+1. **Documentation** (Structured tier) — rules in CLAUDE.md
+2. **Custom linters/hooks** (Verified tier) — scripts that parse output and report violations
+3. **CI/CD gates** — PR cannot merge if checks fail
+
+Verified projects catch phantom completions (agent declares work done that doesn't pass tests), convention drift (agent uses wrong patterns), and confidence without verification (agent presents incorrect output with certainty).
+
+**Example — Verified enforcement:**
+
+```json
+// .claude/settings.json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "command": "npx eslint --fix $FILE && npx prettier --write $FILE"
+      }
+    ]
+  }
+}
+```
+
+Now the agent cannot write a file that violates lint rules — the hook catches it immediately, before errors compound.
+
+**What "clear feedback" means:** When a hook fails, the error message must tell the agent exactly what went wrong and how to fix it. "Lint failed" is insufficient. "ESLint: no-unused-vars in src/utils/helper.ts:42 — remove unused import `foo`" is clear feedback. Without clear feedback, verification creates frustration rather than improvement.
+
+---
+
+### Tier 4: Self-Correcting (7 rules)
+
+**What it means:** The harness detects and corrects its own decay. It improves over time rather than degrading.
+
+**Requirements:**
+
+| Rule                          | Category     | What it checks                                                              |
+| ----------------------------- | ------------ | --------------------------------------------------------------------------- |
+| contradictions                | Instructions | CLAUDE.md is checked for internal contradictions                            |
+| stale-references              | Instructions | CLAUDE.md references are checked for staleness (paths that no longer exist) |
+| code-review-results           | Continuity   | Code review results are tracked and stored                                  |
+| structure-drift               | Continuity   | Project structure matches the declared structure (structure.json)           |
+| memory-curated                | Continuity   | Memory files are curated, not just accumulated                              |
+| critical-decisions-documented | Continuity   | Important architectural decisions are documented (ADRs)                     |
+| self-verification             | Tools        | The agent has tools to verify its own work                                  |
+
+**Rationale:** Every harness degrades over time. File paths change but CLAUDE.md references do not get updated. New conventions emerge but old ones remain documented. Memory files accumulate stale context. Structure drifts from the declared layout.
+
+Self-correcting projects have mechanisms to detect this decay:
+
+- **Stale reference detection** catches CLAUDE.md entries pointing to files that no longer exist
+- **Contradiction detection** catches conflicting instructions within the same document
+- **Structure drift detection** catches files that exist on disk but are not registered in structure.json (or vice versa)
+- **Code review tracking** creates a feedback loop — findings from reviews drive harness improvements
+- **Memory curation** ensures the agent's persistent context stays relevant
+
+**The feedback loop:** Code review findings at the Self-Correcting tier are not just bug reports — they are harness audits. Every finding that reaches review is evidence of a gap: the documentation did not prevent it, automation did not catch it, or the agent lacked context. Tracking these findings over time reveals patterns and drives systematic improvement.
+
+---
+
+## Enforcement vs. Existence
+
+The central insight of this maturity model: **the presence of a rule in CLAUDE.md is not the same as enforcement of that rule.**
+
+| Level           | Mechanism                                                  | Strength                                            | Tier            |
+| --------------- | ---------------------------------------------------------- | --------------------------------------------------- | --------------- |
+| Documentation   | Written instructions in CLAUDE.md                          | Weakest — agent tries to follow but skips shortcuts | Structured      |
+| Automation      | Hooks, linters, scripts that catch violations              | Strong — mechanical, consistent, immediate feedback | Verified        |
+| Gates           | CI/CD checks that block merging on failure                 | Strongest — ultimate guarantee                      | Verified        |
+| Self-correction | Mechanisms that detect harness decay and drive improvement | Sustaining — keeps the system healthy over time     | Self-Correcting |
+
+A project with a 200-line CLAUDE.md and zero hooks is Structured, not Verified. A project with hooks that run but produce unclear error messages is not fully Verified (clear-feedback rule fails). The tier system measures what the harness _does_, not what it _says_.
+
+## Recommendations
+
+### Mechanisms that work (proven in this project)
+
+- **PostToolUse hooks on Edit/Write** for immediate lint + format feedback
+- **Pre-commit hooks** (husky + lint-staged) as a safety net for manual edits
+- **Deny rules** in .claude/settings.json for dangerous operations (force push, destructive git commands)
+- **Off-limits file lists** to protect critical configuration
+- **structure.json** as a declarative manifest of project layout — agents reference it instead of hardcoding paths
+- **Code review results tracked per issue** to create a measurable feedback loop
+- **ADRs** (Architecture Decision Records) for documenting decisions the agent needs to know about
+
+### Progression path
+
+1. **Start with Minimal:** Create a CLAUDE.md with real content
+2. **Move to Structured:** Add tech stack, architecture, constraints, context management guidance
+3. **Move to Verified:** Add hooks, permissions, deny rules — this is where the biggest improvement happens
+4. **Move to Self-Correcting:** Add contradiction detection, code review tracking, structure drift detection
+
+Most projects should aim for Verified as a working target. Self-Correcting is for projects with active, ongoing AI-assisted development where harness maintenance is a continuous concern.
+
+## Anti-Patterns
+
+### Decorative configurations
+
+A .claude/settings.json that exists but contains no hooks, no permissions, and no deny rules. The file's presence satisfies no audit rules — the rules check for specific content, not file existence.
+
+### Untested fixtures
+
+Test fixtures (sample project directories) that demonstrate harness patterns but are never actually validated by tests. The fixture looks like a good harness but nothing verifies it works.
+
+### Open feedback loops
+
+Code review findings that are noted but never tracked, never measured, and never drive harness improvements. Without closing the loop (finding leads to harness change leads to fewer findings), the same mistakes repeat.
+
+### Vague instructions
+
+CLAUDE.md entries like "follow best practices" or "use established patterns" that provide no actionable guidance. The specificity rule at Structured tier catches this — instructions must reference concrete file paths, specific technologies, and measurable requirements.
+
+### Over-tooling
+
+Configuring many MCP servers "just in case." Each additional tool increases the agent's decision space and wastes tokens on tool selection. The mcp-count rule flags projects with excessive tool configurations. Fewer, well-scoped tools outperform many loosely-scoped ones.
+
+### Instructions without enforcement
+
+The most common anti-pattern: writing detailed instructions in CLAUDE.md but never adding hooks to verify compliance. This creates a false sense of security — the instructions exist, so the project feels well-harnessed, but there is no mechanical guarantee the agent follows them.
+
+## Scoring
+
+Rules are weighted by severity:
+
+- **Critical:** 3 points
+- **Important:** 2 points
+- **Recommended:** 1 point
+
+Tier assignment uses total earned points against calibrated thresholds. A tier is "achieved" only when all non-skipped rules at that tier (and all lower tiers) pass. This means a single failing Minimal rule blocks achievement of Structured, Verified, and Self-Correcting tiers.
+
+## Categories
+
+The audit organizes rules into seven categories that map to the harness pillars:
+
+| Category     | Pillar                     | What it covers                                   |
+| ------------ | -------------------------- | ------------------------------------------------ |
+| Instructions | Documentation/Memory       | CLAUDE.md content quality and completeness       |
+| Verification | Verification/Back-pressure | Hooks, linters, automated checks                 |
+| Constraints  | Architecture/Constraints   | Permissions, deny rules, scope limits            |
+| Context      | Context Management         | Session scoping, compact guidance, sub-agents    |
+| Tools        | Tools/Capabilities         | MCP configuration, tool scoping                  |
+| Continuity   | Documentation/Memory       | Memory curation, onboarding, decision tracking   |
+| Architecture | Architecture/Constraints   | Config files, enforcement level, banned patterns |

--- a/standards/issue-authoring-guide-kit.md
+++ b/standards/issue-authoring-guide-kit.md
@@ -1,0 +1,201 @@
+# Issue Authoring Guide for Claude Implementation
+
+> **Extracted from CLAUDE.md** -- This is the comprehensive reference for creating GitHub issues that Claude AI agents will implement.
+
+---
+
+**IMPORTANT:** When creating GitHub issues that will be implemented by Claude AI agents, include comprehensive implementation details to enable autonomous work.
+
+## Required Sections in Issues
+
+1. **Problem Statement**
+   - Clear description of current state vs desired state
+   - User impact (current experience vs expected experience)
+   - Why this matters (value proposition)
+
+2. **Acceptance Criteria**
+   - Checkbox list of specific deliverables
+   - Expected behavior in detail
+   - Edge cases to handle
+   - Performance/quality requirements
+
+3. **Quality Budget**
+   - Explicit numeric targets as checkboxes -- agents enforce what's measurable
+   - Test-to-code ratio target (>= 1.0 for engine, >= 0.5 minimum with justification)
+   - File size limits (< 300 lines, type files exempt). Break by purpose when decomposing files.
+   - Function complexity limits (<= 10 cyclomatic)
+   - Barrel export constraints (only consumed symbols)
+   - These are **acceptance criteria the agent must verify before creating a PR**
+
+4. **Known Risks / Discrepancies**
+   - Upfront audit results -- don't let agents discover surprises mid-implementation
+   - Known behavioral differences between old and new code
+   - Private/unexported functions that block ground truth testing
+   - Cross-module dependencies that may cause cascading changes
+   - UI dependencies to exclude from migration
+   - If no risks: state "None identified" so the agent knows it was considered
+
+5. **Implementation Details**
+   - Recommended approach (with alternatives if applicable)
+   - File structure and organization
+   - Code examples/snippets for key patterns
+   - Integration points with existing code
+   - State management approach
+
+6. **Testing Requirements**
+   - Manual testing checklist
+   - Automated testing requirements (unit, integration, E2E)
+   - Edge cases to verify
+   - Expected test outputs
+
+7. **Technical Specifications**
+   - Data structures
+   - API contracts
+   - Component props/interfaces
+   - Constants/configuration
+
+8. **Related Files**
+   - List files that need modification
+   - List files for reference/context
+   - Dependencies to install
+
+9. **Definition of Done**
+   - Comprehensive checklist of completion criteria
+   - Include code review, testing, documentation requirements
+   - **Must include:** "All quality budget targets verified before PR creation"
+   - **Must include:** "No file over 200 lines (type files exempt)"
+   - **Must include:** "No function over 10 cyclomatic complexity"
+
+## Issue Authoring Rules
+
+These rules apply when Claude creates issues for agent implementation:
+
+**Conditional UI requires explicit validation ACs.** When a story includes conditional sections (optional panels, feature toggles), the acceptance criteria MUST specify validation behavior for both states. Example:
+
+> - [ ] Tests cover: condition on + fields empty = blocked; condition off = passes without spouse fields
+
+**New UI surfaces with 3+ cards/sections need design-first.** Split into two stories: (1) design doc + component decomposition plan, (2) implementation from the design. This pattern saved significant rework. The design story should produce a `.claude/temp/DESIGN-*-REMOVE.md` that the implementation story consumes.
+
+**Wire for testing in Definition of Done.** Every story that adds a new UI surface must include:
+
+> - [ ] Component is visually testable via `npm run dev` (temporary toggle/route if permanent navigation not yet built)
+
+**Reference epic learnings when applicable.** If the story belongs to an active epic with a learnings doc (e.g., `docs/epics/epic2-learnings.md`), include it in Related Files so the agent has context about available engine modules, proven patterns, and known health budget candidates.
+
+## Best Practices
+
+**DO:**
+
+- Provide complete code examples for complex patterns
+- Include expected file paths (absolute paths preferred)
+- Document edge cases explicitly, especially for conditional UI states
+- Specify testing approach and expected coverage
+- Include design guidelines (visual style, content tone)
+- List related standards documents
+- Provide context for architectural decisions
+- Include success metrics when applicable
+- Reference epic learnings docs in Related Files when applicable
+- Call out wire-for-testing requirements in Definition of Done
+
+**DON'T:**
+
+- Use vague requirements ("make it better")
+- Assume the implementing agent knows project-specific conventions
+- Skip testing requirements
+- Omit file structure details
+- Leave implementation approach ambiguous
+- Forget to specify mobile/responsive requirements
+- Skip accessibility considerations
+- Omit conditional validation requirements for toggle-dependent UI
+- Combine design + implementation for complex UI (3+ cards) in one story
+
+## Example Issue Structure
+
+```markdown
+# [Feature Name]
+
+## Problem Statement
+
+Current state: [describe problem]
+Expected state: [describe solution]
+User impact: [explain value]
+
+## Acceptance Criteria
+
+- [ ] Specific deliverable 1
+- [ ] Specific deliverable 2
+- [ ] Edge case handling
+- [ ] Performance requirements met
+
+## Quality Budget
+
+- [ ] Test-to-code ratio >= [target] (source lines: [N], test lines needed: [N])
+- [ ] No function > 10 cyclomatic complexity
+- [ ] No file > 200 lines (type files exempt)
+- [ ] Barrel exports only for consumed symbols
+
+## Known Risks / Discrepancies
+
+- [Risk 1]: [description and mitigation]
+- [Risk 2]: [description and mitigation]
+- Private/unexported functions: [list or "None"]
+- UI dependencies to exclude: [list or "None"]
+
+## Health Budget (Boy Scout Rule)
+
+- [ ] Focus: [decomposition | coverage | complexity]
+- [ ] Target: [specific improvement, e.g., "split ComponentX.jsx from 280 to 2 files under 200"]
+- [ ] Baseline: [current metric value from last collect-all.sh run]
+- [ ] Result: [measured value after implementation]
+
+## Implementation Details
+
+### Recommended Approach
+
+[Describe approach with rationale]
+
+### File Structure
+```
+
+path/to/files/
+├── Component.jsx
+├── Component.test.jsx
+└── index.js
+
+````
+
+### Code Examples
+```javascript
+// Example implementation
+````
+
+### Integration Points
+
+- Modify: `path/to/file.jsx` (add X to Y)
+- Reference: `path/to/related.jsx` (for pattern)
+
+## Testing Requirements
+
+- [ ] Manual test: [scenario]
+- [ ] E2E test: [scenario]
+- [ ] Unit test: [function]
+
+## Related Files
+
+- `path/to/standard.md` - Standard to follow
+- `path/to/component.jsx` - Similar pattern
+
+## Definition of Done
+
+- [ ] Implementation complete
+- [ ] Tests passing
+- [ ] All quality budget targets verified before PR creation
+- [ ] No file over 200 lines (type files exempt)
+- [ ] No function over 10 cyclomatic complexity
+- [ ] Health budget target achieved (Boy Scout Rule)
+- [ ] Code reviewed
+- [ ] Documentation updated
+
+```
+
+```

--- a/standards/quick-ref/craftsmanship-kit.md
+++ b/standards/quick-ref/craftsmanship-kit.md
@@ -1,0 +1,41 @@
+# Code Craftsmanship Standards
+
+## KISS (Keep It Simple)
+
+Prefer the straightforward solution. If an approach needs a paragraph to explain, find a simpler one. Flat is better than nested. Small functions over clever one-liners.
+
+## DRY (Don't Repeat Yourself)
+
+Extract shared logic when the same pattern appears three or more times. Two similar blocks are fine — three means refactor. But never DRY at the cost of readability.
+
+## YAGNI (You Aren't Gonna Need It)
+
+Do not build for hypothetical future requirements. No feature flags, extension points, or abstractions "in case we need it later." Solve today's problem today.
+
+## Readability and Intent
+
+Code should communicate _why_, not just _what_. Use descriptive names that reveal purpose. A reader should understand a function's intent without reading its body. Comments explain _why_ something unusual exists, not _what_ the code does.
+
+## Intent Over Mechanics
+
+Rules express the _why_, not just the _what_. A rule that says "write a one-line JSDoc" tells agents what to type but not what to achieve. Prefer: "document behavior that could surprise callers." When agents understand the intent, they generalize correctly to novel situations instead of complying with the letter and missing the spirit.
+
+## Consistency Over Cleverness
+
+Match the patterns already in the codebase. A consistent codebase where every file looks familiar is worth more than a locally optimal but unfamiliar approach. When in doubt, do it the way the rest of the project does it.
+
+## Small, Related Commits
+
+Commit early and often as logical units of work complete. A commit should capture one coherent change — a new type, a new function, a wiring step, a test suite. Do not batch all changes into a single commit at the end. Small commits are easier to review, easier to revert, and tell the story of how the implementation was built.
+
+## Search Before Building
+
+Before creating a new function, type, or helper, search the codebase for existing implementations that serve the same purpose. If a similar function exists, reuse or extend it rather than creating a duplicate.
+
+## Safe Content Moves During Refactoring
+
+When moving content between files, verify the target file contains the moved content before deleting from the source. Never delete-then-recreate — the intermediate state where content exists in neither file is a data-loss risk that hooks and tests cannot catch.
+
+## Prefer Native Builtins
+
+Prefer native language and platform built-ins over custom reimplementations. Before writing a utility function, search docs for an existing API that serves the same purpose. Custom utilities are justified only when the native API has an ergonomic gap that affects multiple call sites.

--- a/standards/quick-ref/database-guide.md
+++ b/standards/quick-ref/database-guide.md
@@ -1,0 +1,88 @@
+# Database Guide
+
+**IMPORTANT:** Claude can query the MySQL database using Sequelize via Node.js one-liners.
+
+## How to Query Database
+
+**Recommended method (uses project .env config):**
+```bash
+cd backend && node -e "
+const db = require('./src/models');
+db.sequelize.query('SELECT COUNT(*) as count FROM books')
+  .then(([results]) => {
+    console.log(JSON.stringify(results, null, 2));
+  })
+  .catch(err => console.error('Error:', err.message))
+  .finally(() => process.exit(0));
+"
+```
+
+**Why this works:**
+- Uses existing `.env` configuration (no password in commands)
+- Full access to Sequelize ORM
+- Can execute any SQL query
+- Returns JSON results
+
+## Common Database Queries
+
+**Check if database exists:**
+```bash
+cd backend && node -e "
+const db = require('./src/models');
+db.sequelize.authenticate()
+  .then(() => console.log('Database connected'))
+  .catch(err => console.error('Error:', err.message))
+  .finally(() => process.exit(0));
+"
+```
+
+**Get table counts:**
+```bash
+cd backend && node -e "
+const db = require('./src/models');
+db.sequelize.query('SHOW TABLES')
+  .then(([tables]) => {
+    console.log('Tables:', tables);
+    return Promise.all(
+      tables.map(t => {
+        const tableName = t['Tables_in_checked_out'];
+        return db.sequelize.query(\`SELECT COUNT(*) as count FROM \${tableName}\`)
+          .then(([result]) => ({ table: tableName, count: result[0].count }));
+      })
+    );
+  })
+  .then(counts => console.log(JSON.stringify(counts, null, 2)))
+  .finally(() => process.exit(0));
+"
+```
+
+**Query specific data:**
+```bash
+cd backend && node -e "
+const db = require('./src/models');
+db.sequelize.query('SELECT * FROM books LIMIT 5')
+  .then(([results]) => console.log(JSON.stringify(results, null, 2)))
+  .finally(() => process.exit(0));
+"
+```
+
+## Database Prerequisites
+
+If you get `Error: Unknown database 'checked_out'`:
+1. Database hasn't been created yet
+2. Document this as a blocker in verification
+3. Provide setup instructions for human
+
+**Setup commands (for human):**
+```bash
+# Create database
+mysql -u root -p <<EOF
+CREATE DATABASE checked_out CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+EOF
+
+# Run migrations
+cd backend && npm run db:migrate
+
+# Seed database (optional)
+npm run db:seed
+```

--- a/standards/quick-ref/harness-standard-kit.md
+++ b/standards/quick-ref/harness-standard-kit.md
@@ -1,0 +1,27 @@
+# Harness Maturity Standard
+
+Four tiers describe how well a project's structured environment supports AI agents. Each tier builds on the one below it — you must achieve lower tiers before claiming higher ones.
+
+## Tier 1: Minimal
+
+A CLAUDE.md file exists and contains meaningful content (not empty or boilerplate). This is the bare minimum for an agent to receive any project-specific guidance.
+
+## Tier 2: Structured
+
+Instructions are specific and actionable. CLAUDE.md documents the tech stack, architecture, and constraints. Subdirectory instruction files exist where needed. Context management practices (session scoping, compact guidance, sub-agent delegation) are documented. Tool configuration is present and scoped appropriately. Architecture config exists. Onboarding quality is sufficient for a new agent session to be productive.
+
+## Tier 3: Verified
+
+Automated enforcement exists — not just documentation. Hooks run linters and tests on agent output. Hook scripts exist and are referenced in settings. Forbidden patterns are mechanically blocked. Feedback from failures is clear and actionable. Permissions, deny rules, off-limits files, and scope rules constrain what the agent can do. Architecture enforcement goes beyond config to active detection of banned patterns.
+
+## Tier 4: Self-Correcting
+
+The harness improves itself over time. Instructions are checked for contradictions and stale references. Code review results are tracked. Structure drift is detected. Memory is curated. The agent can verify its own work. This tier requires active maintenance, not just initial setup.
+
+## Key Insight
+
+**Existence is not enforcement.** A CLAUDE.md that says "run tests" is Structured. A hook that actually runs tests and blocks on failure is Verified. The gap between tiers 2 and 3 is the gap between documentation and automation.
+
+## Progression
+
+Start at Minimal, work upward. Each tier delivers compounding value. Most projects see the biggest improvement moving from Structured to Verified — that is where phantom completions and convention drift get caught mechanically.

--- a/standards/quick-ref/testing-guide.md
+++ b/standards/quick-ref/testing-guide.md
@@ -1,0 +1,82 @@
+# Testing Guide
+
+**CRITICAL:** When implementing features, you MUST test them before creating verification document.
+
+## Backend Testing
+
+**Run seeders:**
+```bash
+cd backend && npm run db:seed
+```
+
+**Test API endpoints:**
+```bash
+# Start server in background
+cd backend && npm run dev &
+SERVER_PID=$!
+
+# Wait for server to start
+sleep 3
+
+# Test endpoint
+curl http://localhost:3000/api/health
+
+# Stop server
+kill $SERVER_PID
+```
+
+**Query database to verify:**
+```bash
+cd backend && node -e "
+const db = require('./src/models');
+db.sequelize.query('SELECT COUNT(*) FROM books')
+  .then(([results]) => console.log('Books:', results[0].count))
+  .finally(() => process.exit(0));
+"
+```
+
+## Frontend Testing
+
+**Start dev server:**
+```bash
+cd frontend && timeout 5 npm run dev || true
+# Note: Use short timeout to verify it starts, don't leave running
+```
+
+**Check for errors:**
+```bash
+cd frontend && npm run build 2>&1 | head -20
+```
+
+## Code Quality
+
+**Always run before creating verification:**
+```bash
+# Backend
+cd backend && npm run lint && npm run format
+
+# Frontend
+cd frontend && npm run lint && npm run format
+```
+
+## Verification Document Format
+
+After implementation, create `.claude/temp/VERIFICATION-<issue#>-REMOVE.md`.
+See [EXAMPLE-VERIFICATION-FORMAT.md](../../.claude/commands/EXAMPLE-VERIFICATION-FORMAT.md) for format.
+
+## Escalation Protocol
+
+**Immediate escalation (don't waste time):**
+- Issue requirements are unclear or ambiguous
+- Multiple valid approaches with unclear trade-offs
+- Architectural decisions needed
+- Cannot access required resources (database, APIs)
+
+**Three-strikes rule:**
+- After 3 failed attempts to fix a bug: Escalate with details
+- After 3 failed test runs: Explain what you tried, ask for help
+
+**Blocking dependencies:**
+- Database doesn't exist: Document in verification, provide setup steps
+- API keys missing: Document requirement, ask human to provide
+- External service down: Note in verification, suggest workarounds


### PR DESCRIPTION
## Summary

- **Rewrote CLAUDE.md** from 420 lines to 58 lines with the six canonical sections (Tech Stack, Architecture, Commands, Constraints, Conventions, Context Guidance)
- **Added `.claude/settings.json`** with permission scoping (allow/deny) and hooks (pre-write file protection, post-write secret scan)
- **Added harness-kit components**: kit commands, agents, knowledge base, and standards
- **Created `standards/code-review.md`** skeleton with severity levels and evaluation criteria
- **Created referenced guides**: `standards/quick-ref/database-guide.md` and `standards/quick-ref/testing-guide.md` (content moved from old CLAUDE.md)
- **Updated `.gitignore`** with kit entries (`.harness-kit.lock`, `code-review-results/`)

## Test plan

- [ ] Verify CLAUDE.md loads correctly in new Claude Code sessions
- [ ] Verify `.claude/settings.json` hooks fire on file writes
- [ ] Run `/story-runner-kit` or `/code-review-pr-kit` to confirm kit commands work
- [ ] Confirm `.gitignore` prevents `code-review-results/` and `.harness-kit.lock` from being tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)