### PR TITLE
fix: allow patrons to rejoin waitlist after stale entry (#246)

### DIFF
--- a/backend/src/services/WaitlistService.js
+++ b/backend/src/services/WaitlistService.js
@@ -2,6 +2,7 @@ const { Op } = require('sequelize');
 const { WaitlistEntry, Patron, Book, Copy, sequelize } = require('../models');
 const ApiError = require('../utils/ApiError');
 const logger = require('../config/logger');
+const withSerializableTransaction = require('../utils/withSerializableTransaction');
 
 class WaitlistService {
   /** Add a patron to the waitlist for a specific book+format */
@@ -15,26 +16,36 @@ class WaitlistService {
       throw ApiError.conflict('Patron account is not active');
     }
 
-    const existing = await WaitlistEntry.findOne({
-      where: { patron_id: patronId, book_id: bookId, format },
-    });
-    if (existing) {
-      throw ApiError.conflict('Already on the waitlist for this book and format');
-    }
+    return withSerializableTransaction(async (transaction) => {
+      const activeEntry = await WaitlistEntry.findOne({
+        where: { patron_id: patronId, book_id: bookId, format, status: 'waiting' },
+        transaction,
+      });
+      if (activeEntry) {
+        throw ApiError.conflict('Already on the waitlist for this book and format');
+      }
 
-    const maxPosition = await WaitlistEntry.max('position', {
-      where: { book_id: bookId, format, status: 'waiting' },
-    });
+      const staleEntry = await WaitlistEntry.findOne({
+        where: { patron_id: patronId, book_id: bookId, format },
+        transaction,
+      });
 
-    const entry = await WaitlistEntry.create({
-      patron_id: patronId,
-      book_id: bookId,
-      format,
-      position: (maxPosition || 0) + 1,
-      status: 'waiting',
-    });
+      const maxPosition = await WaitlistEntry.max('position', {
+        where: { book_id: bookId, format, status: 'waiting' },
+        transaction,
+      });
+      const nextPosition = (maxPosition || 0) + 1;
 
-    return entry;
+      if (staleEntry) {
+        await staleEntry.update({ status: 'waiting', position: nextPosition }, { transaction });
+        return staleEntry;
+      }
+
+      return WaitlistEntry.create(
+        { patron_id: patronId, book_id: bookId, format, position: nextPosition, status: 'waiting' },
+        { transaction }
+      );
+    });
   }
 
   /** Remove a patron from the waitlist and reorder remaining positions */

--- a/backend/src/services/WaitlistService.js
+++ b/backend/src/services/WaitlistService.js
@@ -26,7 +26,7 @@ class WaitlistService {
       }
 
       const staleEntry = await WaitlistEntry.findOne({
-        where: { patron_id: patronId, book_id: bookId, format },
+        where: { patron_id: patronId, book_id: bookId, format, status: { [Op.ne]: 'waiting' } },
         transaction,
       });
 

--- a/backend/src/services/WaitlistService.race.test.js
+++ b/backend/src/services/WaitlistService.race.test.js
@@ -13,17 +13,14 @@ const mockBook = { findByPk: vi.fn() };
 const mockPatron = { findByPk: vi.fn() };
 
 const mockTransaction = { id: 'tx-1' };
-const transactionMock = vi.fn();
 
 injectMock('../models', {
   WaitlistEntry: mockWaitlistEntry,
   Book: mockBook,
   Patron: mockPatron,
   Copy: {},
-  sequelize: { transaction: transactionMock },
-  Sequelize: {
-    Transaction: { ISOLATION_LEVELS: { SERIALIZABLE: 'SERIALIZABLE' } },
-  },
+  sequelize: {},
+  Sequelize: {},
 });
 
 // Mock withSerializableTransaction to execute the callback directly with a mock transaction

--- a/backend/src/services/WaitlistService.race.test.js
+++ b/backend/src/services/WaitlistService.race.test.js
@@ -1,0 +1,132 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { setupMockRequire } from '../test-utils/mockRequire.js';
+
+const { require, injectMock } = setupMockRequire(import.meta.url);
+
+const mockWaitlistEntry = {
+  findOne: vi.fn(),
+  max: vi.fn(),
+  create: vi.fn(),
+};
+
+const mockBook = { findByPk: vi.fn() };
+const mockPatron = { findByPk: vi.fn() };
+
+const mockTransaction = { id: 'tx-1' };
+const transactionMock = vi.fn();
+
+injectMock('../models', {
+  WaitlistEntry: mockWaitlistEntry,
+  Book: mockBook,
+  Patron: mockPatron,
+  Copy: {},
+  sequelize: { transaction: transactionMock },
+  Sequelize: {
+    Transaction: { ISOLATION_LEVELS: { SERIALIZABLE: 'SERIALIZABLE' } },
+  },
+});
+
+// Mock withSerializableTransaction to execute the callback directly with a mock transaction
+injectMock('../utils/withSerializableTransaction', async (fn) => fn(mockTransaction));
+
+const waitlistService = require('./WaitlistService');
+const ApiError = require('../utils/ApiError');
+
+const BOOK_ID = 1;
+const FORMAT = 'physical';
+
+function stubBookAndPatron(patronId) {
+  mockBook.findByPk.mockResolvedValue({ id: BOOK_ID });
+  mockPatron.findByPk.mockResolvedValue({ id: patronId, status: 'active' });
+}
+
+describe('WaitlistService.joinQueue race conditions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('two different patrons joining concurrently get distinct positions', async () => {
+    let callCount = 0;
+    mockWaitlistEntry.findOne.mockResolvedValue(null);
+    mockWaitlistEntry.max.mockImplementation(async () => {
+      callCount += 1;
+      return callCount === 1 ? 0 : 1;
+    });
+    mockWaitlistEntry.create.mockImplementation(async (data) => ({ ...data, id: data.position }));
+
+    stubBookAndPatron(10);
+    const p1 = waitlistService.joinQueue(10, BOOK_ID, FORMAT);
+
+    stubBookAndPatron(20);
+    const p2 = waitlistService.joinQueue(20, BOOK_ID, FORMAT);
+
+    const results = await Promise.allSettled([p1, p2]);
+
+    expect(results[0].status).toBe('fulfilled');
+    expect(results[1].status).toBe('fulfilled');
+    expect(results[0].value.position).not.toBe(results[1].value.position);
+  });
+
+  it('rejects with 409 when patron already has a waiting entry', async () => {
+    mockWaitlistEntry.findOne.mockImplementation(async ({ where }) => {
+      if (where.status === 'waiting') {
+        return { id: 1, patron_id: 10, book_id: BOOK_ID, format: FORMAT, status: 'waiting' };
+      }
+      return null;
+    });
+
+    stubBookAndPatron(10);
+
+    await expect(waitlistService.joinQueue(10, BOOK_ID, FORMAT)).rejects.toThrow(
+      'Already on the waitlist for this book and format'
+    );
+
+    const error = await waitlistService.joinQueue(10, BOOK_ID, FORMAT).catch((e) => e);
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.statusCode).toBe(409);
+    expect(mockWaitlistEntry.create).not.toHaveBeenCalled();
+  });
+
+  it('soft-resets a stale entry instead of creating a duplicate', async () => {
+    const staleEntry = {
+      id: 5,
+      patron_id: 10,
+      book_id: BOOK_ID,
+      format: FORMAT,
+      status: 'notified',
+      update: vi.fn().mockResolvedValue(undefined),
+    };
+
+    mockWaitlistEntry.findOne.mockImplementation(async ({ where }) => {
+      if (where.status === 'waiting') return null;
+      return staleEntry;
+    });
+    mockWaitlistEntry.max.mockResolvedValue(3);
+
+    stubBookAndPatron(10);
+    const result = await waitlistService.joinQueue(10, BOOK_ID, FORMAT);
+
+    expect(result).toBe(staleEntry);
+    expect(staleEntry.update).toHaveBeenCalledWith(
+      { status: 'waiting', position: 4 },
+      { transaction: mockTransaction }
+    );
+    expect(mockWaitlistEntry.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a new entry when no existing entry is found', async () => {
+    mockWaitlistEntry.findOne.mockResolvedValue(null);
+    mockWaitlistEntry.max.mockResolvedValue(2);
+    mockWaitlistEntry.create.mockImplementation(async (data) => ({ ...data, id: 99 }));
+
+    stubBookAndPatron(10);
+    const result = await waitlistService.joinQueue(10, BOOK_ID, FORMAT);
+
+    expect(result.position).toBe(3);
+    expect(result.status).toBe('waiting');
+    expect(mockWaitlistEntry.create).toHaveBeenCalledWith(
+      expect.objectContaining({ patron_id: 10, position: 3, status: 'waiting' }),
+      { transaction: mockTransaction }
+    );
+  });
+});

--- a/code-review-results/2026-04-14-issue-246.md
+++ b/code-review-results/2026-04-14-issue-246.md
@@ -1,0 +1,61 @@
+# Code Review: Issue #246 — 2026-04-14
+
+## Files Reviewed
+
+- `backend/src/services/WaitlistService.js` (modified — stale entry rejoin logic with serializable transaction)
+- `backend/src/services/WaitlistService.race.test.js` (new — race condition tests for joinQueue)
+
+## Findings
+
+| Severity | File | Issue | Pillar | Resolved |
+| -------- | ---- | ----- | ------ | -------- |
+| Medium | `backend/src/services/WaitlistService.race.test.js:16` | Unused `transactionMock` variable — injected into models mock but never referenced since `withSerializableTransaction` is independently mocked | Verification | No |
+| Low | `backend/src/services/WaitlistService.js:28-30` | Second `findOne` for stale entry does not explicitly exclude `status: 'waiting'` — relies on prior early return; adding `status: { [Op.ne]: 'waiting' }` would make intent clearer | Documentation | No |
+| Low | `backend/src/services/WaitlistService.race.test.js:48-68` | Concurrent position test mocks `withSerializableTransaction` to pass-through, so no real serialization contention is exercised — test verifies call structure but not isolation behavior | Verification | No |
+
+| Severity | Count |
+| -------- | ----- |
+| Critical | 0 |
+| High | 0 |
+| Medium | 1 |
+| Low | 2 |
+
+## Harness Improvement Recommendations
+
+| Finding | Harness Recommendation | Harness Change Made |
+| ------- | ---------------------- | ------------------- |
+| Unused mock variable | ESLint `no-unused-vars` should catch this in test files — verify it is enabled for `*.test.js` patterns | No |
+
+## Harness Self-Audit
+
+Audit source: CLI + inline checks
+
+| Category | Score | Pass | Fail |
+| ------------ | ----: | ---: | ---: |
+| Instructions | 76% | 8 | 2 |
+| Verification | 64% | 4 | 1 |
+| Constraints | 100% | 4 | 0 |
+| Context | 75% | 3 | 1 |
+| Tools | 100% | 2 | 0 |
+| Session | 60% | 2 | 2 |
+| Architecture | 33% | 1 | 1 |
+
+**Overall:** 71% (Decent)
+
+### No Drift Detected
+
+No harness drift detected. All declared files and references are consistent. All files referenced in CLAUDE.md exist on disk.
+
+## Suggested E2E Tests
+
+Based on the changes in this review, the following end-to-end tests are recommended:
+
+| # | Scenario | Steps | Expected Result | Priority |
+|---|----------|-------|-----------------|----------|
+| 1 | Patron rejoins waitlist after stale (notified/cancelled) entry | Log in as patron, join waitlist for a book, have the entry move to notified/cancelled state, attempt to rejoin the same waitlist | Patron successfully rejoins the waitlist with a new position at the end of the queue | High |
+| 2 | Patron cannot double-join an active waitlist entry | Log in as patron, join a waitlist, attempt to join the same waitlist again while status is still 'waiting' | 409 Conflict error returned, no duplicate entry created | Medium |
+| 3 | Concurrent join requests yield distinct positions | Two different patrons simultaneously request to join the same book+format waitlist | Both patrons are added with unique, sequential positions; no position collision | Medium |
+
+### Notes
+- The stale-entry rejoin scenario is the core behavior this PR adds and should be prioritized for E2E coverage.
+- Concurrent position tests may be difficult to reproduce reliably in E2E; the serializable transaction provides the database-level guarantee, so the unit-level race test may suffice for that scenario.

--- a/harness-audit.json
+++ b/harness-audit.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "timestamp": "2026-04-07T17:32:31.168Z",
+  "timestamp": "2026-04-14T18:10:10.739Z",
   "projectRoot": "/Users/jmcrider/vscode/checked-out",
   "detectedStack": "Web — TypeScript",
   "overallScore": 71,
@@ -95,9 +95,9 @@
     {
       "ruleId": "instructions.claude-md-length",
       "status": "fail",
-      "message": "CLAUDE.md is 103 lines — too long",
+      "message": "CLAUDE.md is 105 lines — too long",
       "evidence": [
-        "103 lines"
+        "105 lines"
       ],
       "fix": "Split CLAUDE.md into a concise root file and subdirectory CLAUDE.md files for detailed guidance."
     },
@@ -129,7 +129,7 @@
     {
       "ruleId": "instructions.stale-references",
       "status": "partial",
-      "message": "6 of 32 referenced path(s) missing",
+      "message": "6 of 36 referenced path(s) missing",
       "evidence": [
         "Missing: sequelize.fn",
         "Missing: sequelize.col",
@@ -281,8 +281,8 @@
     {
       "ruleId": "context.harness-complexity",
       "status": "pass",
-      "message": "Harness complexity: 59 artifacts, 11379 lines (ratio N/A (no source files))",
-      "details": "Harness: 59 artifacts, 11379 lines\nSource: 0 files, 0 lines\nRatio: N/A (no source files)\nBreakdown:\n  instruction: 1 files, 103 lines\n  enforcement: 1 files, 99 lines\n  reference: 32 files, 5773 lines\n  workflow: 25 files, 5404 lines"
+      "message": "Harness complexity: 59 artifacts, 11424 lines (ratio N/A (no source files))",
+      "details": "Harness: 59 artifacts, 11424 lines\nSource: 0 files, 0 lines\nRatio: N/A (no source files)\nBreakdown:\n  instruction: 1 files, 105 lines\n  enforcement: 1 files, 99 lines\n  reference: 32 files, 5816 lines\n  workflow: 25 files, 5404 lines"
     },
     {
       "ruleId": "tools.mcp-configured",
@@ -329,10 +329,10 @@
     {
       "ruleId": "continuity.code-review-results",
       "status": "pass",
-      "message": "Code review results directory found with 68 entry/entries",
+      "message": "Code review results directory found with 71 entry/entries",
       "evidence": [
         "Directory: code-review-results/",
-        "Entries: 68"
+        "Entries: 71"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- **Fixed** `joinQueue()` blocking patrons from rejoining a waitlist when a stale non-waiting entry (notified/fulfilled/cancelled) existed for the same book+format
- **Implemented soft-reset approach**: reuses the existing DB row by updating its status back to `waiting` with a new position, preserving the unique constraint as a safety net
- **Wrapped aggregate-then-write** (`MAX(position)` then create/update) in `withSerializableTransaction` to prevent race conditions with duplicate positions
- **Added race-condition tests** (`WaitlistService.race.test.js`) as required by CLAUDE.md for services using `withSerializableTransaction`

Closes #246

## Test plan
- [x] Existing backend tests pass (72/72)
- [x] New race-condition tests pass (4 tests covering concurrent joins, 409 conflict, soft-reset, and fresh create)
- [x] Smoke tests pass (9/9)
- [x] Lint and format clean
- [x] `check-race-tests.sh` harness passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)